### PR TITLE
fleshing out inventory placement example for logistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tools/replay_lp/log
 tools/schedule_meta
 visualization/
 maro/simulator/scenarios/ecr/
+maro/utils/dashboard/resource.tar.gz

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ MARO(Multi-Agent Resource Optimization) is a multi-agent resource optimization p
 ```sh
 pip install -r requirements.dev.txt
 export PYTHONPATH=$PWD:$PYTHONPATH
+python maro/utils/dashboard/package_data.py
 bash build_maro.sh
 ```
 

--- a/examples/hello_world/logistics/hello.py
+++ b/examples/hello_world/logistics/hello.py
@@ -2,41 +2,34 @@ from maro.simulator import Env
 from maro.simulator.scenarios.logistics.common import Action
 from random import randint
 
+
 MAX_EPISODE = 1
-MAX_TICKS = 1000 # max_episode_length
+MAX_TICKS = 10 # max_episode_length
+
 
 def start():
-    env = Env(scenario="logistics", topology="sample", start_tick=0, max_tick=MAX_TICKS)
-    reward = None
-    decision_event = None
-    is_done = False
+    env = Env(scenario="logistics", topology="inventory_placement", start_tick=0, max_tick=MAX_TICKS)
 
     for episode in range(MAX_EPISODE):
         env.reset()
 
         # NOTE: first action must be None
-        action = None
+        env.step(None)
 
+        rewards = []
+        is_done = False
         while not is_done:
-            # NOTE: the env will take a snapshot (history) when it needs an action
+            action = Action(0, randint(1, 10))
             reward, decision_event, is_done = env.step(action)
+            if not is_done: 
+                rewards.append(reward)
 
-            action = Action(randint(1, 10))
-            # action = 0
-
-        # following code show how to retrieve states from snapshotlist
-        stock_at_all_tick = env.snapshot_list.static_nodes[::("stock", 0)]
-
-        # print(stock_at_all_tick)
-
-        # since our business engine will stop before reach the max tick, so we should use current tick as upper bound to query valid sequence
-        ticks = [i for i in range(env.tick+1)] # include last tick
-
-        stock_to_the_end = env.snapshot_list.static_nodes[ticks::("stock", 0)]
-
-        print("stock till the stop tick")
-        print(stock_to_the_end)
-
+    feature_names = ["demand", "stock", "fulfilled", "unfulfilled"]
+    features = env.snapshot_list.static_nodes[:0:(feature_names, 0)]
+    features = features.reshape(len(env.snapshot_list), len(feature_names)) # one tick one row, features in each row
+    print(feature_names)
+    print(features)
+    print("rewards: {}".format(rewards))
         
 
 if __name__ == "__main__":

--- a/examples/hello_world/logistics/q_learning/common/__init__.py
+++ b/examples/hello_world/logistics/q_learning/common/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+

--- a/examples/hello_world/logistics/q_learning/common/action_shaping.py
+++ b/examples/hello_world/logistics/q_learning/common/action_shaping.py
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+class DiscreteActionShaping():
+    def __init__(self, action_space: [float]):
+        '''
+        Init action shaping.
+        Args:
+            action_space ([float]): Discrete action space, which must include a zero
+                                    action, can be symmetry or asymmetric.
+                                    i.e. [-1.0, -0.9, ... , 0 , ... , 0.9, 1.0]
+                                         [-1.0, -0.5, 0, ... , 0.9, 1.0]
+        '''
+        self._action_space = action_space
+        
+
+    def __call__(self, action_idx: int, warehouse_scope: int) -> int:
+        '''
+        Args:
+            scope (ActionScope): Action actual available scope.
+            action_index (int): Module output.
+        '''
+
+        return int(self._action_space[action_idx] * warehouse_scope)
+
+    @property
+    def action_space(self):
+        return self._action_space

--- a/examples/hello_world/logistics/q_learning/common/agent.py
+++ b/examples/hello_world/logistics/q_learning/common/agent.py
@@ -1,0 +1,177 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+from datetime import datetime
+import os
+import sys
+import random
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from maro.utils import SimpleExperiencePool, Logger, LogFormat
+from maro.simulator.scenarios.logistics.common import Action, DecisionEvent
+
+
+class Agent(object):
+    def __init__(self, agent_name, algorithm, experience_pool: SimpleExperiencePool,
+                 state_shaping, action_shaping, reward_shaping,
+                 batch_num, batch_size, min_train_experience_num,
+                 log_folder: str = None,
+                 dashboard: object = None):
+        self._agent_name = agent_name
+        self._algorithm = algorithm
+        self._experience_pool = experience_pool
+        self._state_shaping = state_shaping
+        self._action_shaping = action_shaping
+        self._reward_shaping = reward_shaping
+        self._batch_size = batch_size
+        self._batch_num = batch_num
+        self._min_train_experience_num = min_train_experience_num
+        self._log_enable = False if log_folder is None else True
+        self._dashboard = dashboard
+        self._neighbors = None
+
+        if self._log_enable:
+            self._logger = Logger(tag='agent', format_=LogFormat.simple,
+                                  dump_folder=log_folder, dump_mode='w', auto_timestamp=False)
+
+    def store_experience(self, current_ep: int):
+        self._reward_shaping.calculate_reward(self._agent_name, current_ep, self._algorithm.learning_index)
+        experience_set = self._reward_shaping.pop_experience(self._agent_name)
+        self._experience_pool.put(category_data_batches=[(name, cache) for name, cache in experience_set.items()])
+        if self._log_enable:
+            experience_summary = {name: experience_set[name] for name in ['action', 'actual_action', 'reward']}
+            self._logger.debug(f'Agent {self._agent_name} new appended exp: {experience_summary}')
+            self._logger.debug(f'Agent {self._agent_name} current experience pool size: {self._experience_pool.size}')
+
+    def get_experience(self, current_ep: int):
+        """
+        return the experience from reward shaping. Only used for distributed mode
+        """
+        self._reward_shaping.calculate_reward(self._agent_name, current_ep, self._algorithm.learning_index)
+        return self._reward_shaping.pop_experience(self._agent_name)
+
+    @property
+    def experience_pool(self):
+        return self._experience_pool
+
+    @property
+    def algorithm(self):
+        return self._algorithm
+
+    def train(self, current_ep: int):
+        """
+        Args:
+            current_ep (int): Current episode, which is used for logging.
+        """
+        # TODO: add per-agent min experience
+        if self._experience_pool.size['info'] < self._min_train_experience_num:
+            return 0
+
+        pbar = tqdm(range(self._batch_num))
+        for i in pbar:
+            pbar.set_description(f'Agent {self._agent_name} batch training')
+            idx_list = self._experience_pool.apply_multi_samplers(
+                category_samplers=[('info', [(lambda i, o: (i, o['td_error']), self._batch_size)])])['info']
+            sample_dict = self._experience_pool.get(category_idx_batches=[
+                ('state', idx_list),
+                ('reward', idx_list),
+                ('action', idx_list),
+                ('next_state', idx_list),
+                ('info', idx_list)
+            ])
+
+            state_batch = torch.from_numpy(
+                np.array(sample_dict['state'])).view(-1, self._algorithm.policy_net.input_dim)
+            action_batch = torch.from_numpy(
+                np.array([sample_dict['action']])).permute(2,1,0)#.view(2, -1, 1)
+            reward_batch = torch.from_numpy(
+                np.array(sample_dict['reward'])).view(-1, 1)
+            next_state_batch = torch.from_numpy(
+                np.array(sample_dict['next_state'])).view(-1, self._algorithm.policy_net.input_dim)
+            loss = self._algorithm.learn(state_batch=state_batch, action_batch=action_batch,
+                                         reward_batch=reward_batch, next_state_batch=next_state_batch,
+                                         current_ep=current_ep)
+
+            # update td-error
+            new_info_list = []
+            for i in range(len(idx_list)):
+                new_info_list.append({'td_error': loss})
+
+            self._experience_pool.update([('info', idx_list, new_info_list)])
+
+            if self._log_enable:
+                self._logger.info(f'{self._agent_name} learn loss: {loss}')
+
+            if self._dashboard is not None:
+                self._dashboard.upload_exp_data(fields={str(self._agent_name): loss}, ep=current_ep, tick=None, measurement='bike_loss')
+
+    def dump_modules(self, module_path: str):
+        self._logger.debug(f'{self._agent_name} dump module to {module_path}')
+        pass
+
+    def load_modules(self, module_path: str):
+        self._logger.debug(f'{self._agent_name} load module from {module_path}')
+        pass
+
+    def choose_action(self, decision_event: DecisionEvent, eps: float, current_ep: int, snapshot_list) -> Action:
+        """
+        Args:
+            decision_event (DecisionEvent): Environment decision event, which includes the action scope, etc.
+            snapshot_list: Environment snapshot.
+            eps (float): Epsilon, which is used for exploration.
+            current_ep (int): Current episode, which is used for logging.
+
+        Returns:
+            (Action): Environment action.
+        """
+
+        action_scope = decision_event.action_scope
+        cur_tick = decision_event.tick
+        cur_warehouse_idx = decision_event.warehouse_idx
+        
+        numpy_state = self._state_shaping(
+            cur_tick=cur_tick, cur_warehouse_idx=cur_warehouse_idx)
+
+        state = torch.from_numpy(numpy_state).view(1, len(numpy_state))
+        is_random, model_action = self._algorithm.choose_action(
+            state=state, eps=eps, current_ep=current_ep, current_tick=cur_tick)
+
+        # station_scope = snapshot_list.static_nodes[cur_tick: cur_station_idx: ('capacity', 0)] - action_scope[cur_station_idx]
+        actual_action = self._action_shaping(action_idx= model_action[1], warehouse_scope=action_scope[cur_warehouse_idx])
+
+        warehouse_states = snapshot_list.static_nodes[
+                      cur_tick: cur_warehouse_idx: (['demand', 'stock'], 0)]
+        self._reward_shaping.push_matrices(self._agent_name,
+                                            {'state': numpy_state,
+                                            'action': model_action,
+                                            'actual_action': [actual_action],
+                                            'action_tick': cur_tick,
+                                            'decision_event': decision_event,
+                                            'eps': eps,
+                                            'warehouse_states':warehouse_states})
+
+        env_action = Action(cur_warehouse_idx, actual_action)
+        if self._log_enable:
+            self._logger.info(
+                f'{self._agent_name} decision_event: {decision_event}, env_action: {env_action}, is_random: {is_random}')
+        return env_action
+
+    def load_policy_net_parameters(self, policy_net_parameters):
+        """
+        load updated policy net parameters to the algorithm.
+        """
+        self._algorithm.load_policy_net_parameters(policy_net_parameters)
+
+    @property
+    def experience_quantity(self):
+        qty = self._experience_pool.size['action']
+        return qty
+
+    @property
+    def model_size(self):
+        size = sum([parameter.nelement() for parameter in self._algorithm.policy_net.parameters()])
+        return size

--- a/examples/hello_world/logistics/q_learning/common/dqn.py
+++ b/examples/hello_world/logistics/q_learning/common/dqn.py
@@ -1,0 +1,272 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+from datetime import datetime
+import os
+import random
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.nn.functional as F
+from torchsummary import summary
+
+from maro.utils import Logger, LogFormat
+
+
+class QNet(nn.Module):
+    '''
+    Deep Q network.
+        Choose multi-layer full connection with dropout as the basic network architecture.
+    '''
+
+    def __init__(self, name: str, input_dim: int, hidden_dims: [int], output_dim: int, dropout_p: float,
+                 log_folder: str = None):
+        '''
+        Init deep Q network.
+
+        Args:
+            name (str): Network name.
+            input_dim (int): Network input dimension.
+            hidden_dims ([int]): Network hiddenlayer dimension. The length of `hidden_dims` means the
+                                hidden layer number, which requires larger than 1.
+            output_dim (int): Network output dimension.
+            dropout_p (float): Dropout parameter.
+        '''
+        super(QNet, self).__init__()
+        assert (len(hidden_dims) > 1)
+        self._name = name
+        self._dropout_p = dropout_p
+        self._input_dim = input_dim
+        self._hidden_dims = hidden_dims
+        self._output_dim = output_dim
+        self._layers = self._build_layers([input_dim] + hidden_dims)
+        self._head1 = nn.Linear(hidden_dims[-1], output_dim)
+        self._head2 = nn.Linear(hidden_dims[-1], output_dim)
+        self._net = nn.Sequential(*self._layers)
+        self._log_enable = False if log_folder is None else True
+        if self._log_enable:
+            self._model_summary_logger = Logger(tag=f'{self._name}.model_summary', format_=LogFormat.none,
+                                                dump_folder=log_folder, dump_mode='w', auto_timestamp=False)
+            self._log_model_parameter_number()
+            self._model_summary_logger.debug(self._net)
+            self._model_parameters_logger = Logger(tag=f'{self._name}.model_parameters', format_=LogFormat.none,
+                                                   dump_folder=log_folder, dump_mode='w', auto_timestamp=False)
+            self.log_model_parameters(-1, -1)
+
+    def forward(self, x):
+        q_values_batch = self._net(x)
+        q_values_batch = torch.stack((self._head1(q_values_batch), self._head2(q_values_batch)),0)
+        return q_values_batch
+
+    @property
+    def input_dim(self):
+        return self._input_dim
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def output_dim(self):
+        return self._output_dim
+
+    def _build_basic_layer(self, input_dim, output_dim):
+        '''
+        Build basic layer.
+            BN -> Linear -> LeakyReLU -> Dropout
+        '''
+        return nn.Sequential(nn.BatchNorm1d(input_dim),
+                             nn.Linear(input_dim, output_dim),
+                             nn.LeakyReLU(),
+                             nn.Dropout(p=self._dropout_p))
+
+    def _build_layers(self, layer_dims: []):
+        '''
+        Build multi basic layer.
+            BasicLayer1 -> BasicLayer2 -> ...
+        '''
+        layers = []
+        for input_dim, output_dim in zip(layer_dims, layer_dims[1:]):
+            layers.append(self._build_basic_layer(input_dim, output_dim))
+        return layers
+
+    def _log_model_parameter_number(self):
+        total_parameter_number = sum([parameter.nelement() for parameter in self._net.parameters()])
+        self._model_summary_logger.debug(f'total parameter number: {total_parameter_number}')
+
+    def log_model_parameters(self, current_ep, learning_index):
+        if self._log_enable:
+            self._model_parameters_logger.debug(
+                f'====================current_ep: {current_ep}, learning_index: {learning_index}=================')
+            for name, param in self._net.named_parameters():
+                self._model_parameters_logger.debug(name, param)
+
+
+class DQN(object):
+    def __init__(self,
+                 policy_net: nn.Module,
+                 target_net: nn.Module,
+                 gamma: float,
+                 tau: float,
+                 lr: float,
+                 target_update_frequency: int,
+                 device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+                 log_folder: str = None, log_dropout_p: float = 0.0,
+                 dashboard: object = None):
+        '''
+        Args:
+            policy_net (nn.Module): Policy Q net, which is used for choosing action.
+            target_net (nn.Module): Target Q net, which is used for evaluating next state.
+            gamma (float): Reward discount factor.
+                         `expected_Q = reward + gamma * max(target_Q(next_state))`
+            tau (float): Soft update parameter.
+                         `target_θ = τ * policy_θ + (1 - τ) * target_θ`
+            lr (float): Learning rate.
+            device: Torch current device.
+        '''
+        super(DQN, self).__init__()
+        self._device = device
+        # self._device = 'cpu'
+        self._policy_net = policy_net.to(self._device)
+        self._policy_net.eval()
+        self._target_net = target_net.to(self._device)
+        self._target_net.eval()
+        self._gamma = gamma
+        self._tau = tau
+        self._lr = lr
+        self._optimizer = optim.RMSprop(
+            self._policy_net.parameters(), lr=self._lr)
+        self._learning_counter = 0
+        self._target_update_frequency = target_update_frequency
+        self._log_enable = False if log_folder is None else True
+        self._log_dropout_p = log_dropout_p
+        self._log_folder = log_folder
+        self._dashboard = dashboard
+        if self._log_enable:
+            self._logger = Logger(tag='dqn', format_=LogFormat.simple,
+                                  dump_folder=log_folder, dump_mode='w', auto_timestamp=False)
+            self._loss_logger = Logger(tag=f'{self._policy_net.name}.loss', format_=LogFormat.none,
+                                       dump_folder=log_folder, dump_mode='w', extension_name='csv',
+                                       auto_timestamp=False)
+            self._loss_logger.debug('episode,learning_index,loss')
+            self._q_curve_logger = Logger(tag=f'{self._policy_net.name}.q_curve', format_=LogFormat.none,
+                                          dump_folder=log_folder, dump_mode='w', extension_name='csv',
+                                          auto_timestamp=False)
+            self._q_curve_logger.debug(
+                'episode,learning_index,' + ','.join([str(i) for i in range(self._policy_net.output_dim)]))
+
+    def choose_action(self, state: torch.Tensor, eps: float, current_ep: int, current_tick: int) -> (bool, int):
+        '''
+        Args:
+            state (tensor): Environment state, which is a tensor.
+            eps (float): Epsilon, which is used for exploration.
+            current_ep (int): Current episode, which is used for logging.
+            current_tick (int): Current tick, which is used for dashboard.
+
+        Returns:
+            (bool, int): is_random, action_index
+        '''
+        state = state.to(self._device)
+        sample = random.random()
+        if sample > eps:
+            with torch.no_grad():
+                q_values_batch = self._policy_net(state)
+                q_values_batch_mean = torch.mean(q_values_batch, dim = 0)
+                if self._log_enable:
+                    sample = random.random()
+                    if sample > self._log_dropout_p: 
+                        for q_values in q_values_batch_mean:
+                            self._q_curve_logger.debug(f'{current_ep},{self._learning_counter},' + ','.join(
+                                [str(q_value.item()) for q_value in q_values]))
+                if self._dashboard is not None:
+                    dashboard_ep = current_ep
+                    if not self._dashboard.dynamic_info['is_train']:
+                        dashboard_ep += self._dashboard.static_info['max_train_ep']
+                    for q_values in q_values_batch[0]:
+                        for i in range(len(q_values)):
+                            scalars = {self._policy_net.name: q_values[i].item(), 'action': i}
+                            self._dashboard.upload_exp_data(fields=scalars, ep=dashboard_ep, tick=current_tick, measurement='bike_q_value_neighbor')
+                    for q_values in q_values_batch[1]:
+                        for i in range(len(q_values)):
+                            scalars = {self._policy_net.name: q_values[i].item(), 'action': i}
+                            self._dashboard.upload_exp_data(fields=scalars, ep=dashboard_ep, tick=current_tick, measurement='bike_q_value_number')
+                
+                action = [x.max(1)[1][0].item() for x in q_values_batch]
+                return False, action
+        else:
+            return True, [random.choice(range(self._policy_net.output_dim)),random.choice(range(self._policy_net.output_dim))]
+
+    def learn(self, state_batch: torch.Tensor, action_batch: torch.Tensor, reward_batch: torch.Tensor,
+              next_state_batch: torch.Tensor, current_ep: int) -> float:
+        state_batch = state_batch.to(self._device)
+        action_batch = action_batch.to(self._device)
+        reward_batch = reward_batch.to(self._device)
+        next_state_batch = next_state_batch.to(self._device)
+
+        self._policy_net.train()
+        policy_state_action_values = self._policy_net(
+            state_batch).gather(2, action_batch.long()).mean(dim=0)
+        # self._logger.debug(f'policy state action values: {policy_state_action_values}')
+
+        target_next_state_values = self._target_net(next_state_batch).max(2)[0].mean(dim=0).view(-1, 1).detach()
+        # self._logger.debug(f'target next state values: {target_next_state_values}')
+
+        expected_state_action_values = reward_batch + \
+                                       self._gamma * target_next_state_values
+
+        # self._logger.debug(f'expected state action values: {expected_state_action_values}')
+
+        loss = F.smooth_l1_loss(
+            policy_state_action_values, expected_state_action_values).mean()
+
+        self._optimizer.zero_grad()
+        loss.backward()
+        for param in self._policy_net.parameters():
+            param.grad.data.clamp_(-1, 1)
+        self._optimizer.step()
+        self._learning_counter += 1
+        self._policy_net.eval()
+        self._soft_update_target_net_parameters()
+
+        if self._log_enable:
+            sample = random.random()
+            if sample > self._log_dropout_p:
+                # self._policy_net.log_model_parameters(current_ep, self._learning_counter)
+                # self._target_net.log_model_parameters(current_ep, self._learning_counter)
+                self._loss_logger.debug(f'{current_ep},{self._learning_counter},{loss.item()}')
+        return loss.item()
+
+    @property
+    def learning_index(self):
+        return self._learning_counter
+
+    def _soft_update_target_net_parameters(self):
+        '''
+        Soft update target model.
+            target_θ = τ*policy_θ + (1 - τ)*target_θ
+        '''
+        if self._learning_counter % self._target_update_frequency == 0:
+            if self._log_enable:
+                self._logger.debug(
+                    f'{self._target_net.name} update model with {self._tau} * policy_param + {1 - self._tau} * target_param.')
+            for policy_param, target_param in zip(self._policy_net.parameters(), self._target_net.parameters()):
+                target_param.data = self._tau * policy_param.data + \
+                                    (1 - self._tau) * target_param.data
+
+    @property
+    def policy_net(self):
+        return self._policy_net
+
+    @property
+    def target_net(self):
+        return self._target_net
+
+    def load_policy_net_parameters(self, policy_param):
+        self._policy_net.load_state_dict(policy_param)
+
+    def dump_policy_net_parameters(self, dump_path):
+        torch.save(self._policy_net.state_dict(), dump_path)
+
+

--- a/examples/hello_world/logistics/q_learning/common/remote_debug.py
+++ b/examples/hello_world/logistics/q_learning/common/remote_debug.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+import os
+from requests import get
+from tabulate import tabulate
+
+if os.environ.get("REMOTE_DEBUG") == "on":
+    port = os.environ.get("REMOTE_DEBUG_PORT")
+
+    if not port:
+        print("WARN: invalid port to enable remote debugging.")
+    else:
+        import ptvsd
+
+        public_ip = get('https://api.ipify.org').text
+        print("*******  Waiting for remote attach  ******")
+        print(tabulate([['remote', public_ip, port], ['local', '127.0.0.1', port]], headers=['Host', 'IP', 'Port']))
+
+        address = ('0.0.0.0', port)
+        ptvsd.enable_attach(address)
+        ptvsd.wait_for_attach()
+
+        print("******  Attached  ******")

--- a/examples/hello_world/logistics/q_learning/common/reward_shaping.py
+++ b/examples/hello_world/logistics/q_learning/common/reward_shaping.py
@@ -1,0 +1,113 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+from collections import defaultdict
+
+import numpy as np
+
+from maro.utils import Logger, LogFormat
+
+class RewardShaping:
+    def __init__(self, env, log_folder: str = './', log_enable: bool = True):
+        self._env = env
+        self._warehouse_idx2name = self._env.node_name_mapping["static"]
+        self._agent_idx_list = self._env.agent_idx_list
+        self._cache = {self._warehouse_idx2name[agent_idx]: defaultdict(list) for agent_idx in self._agent_idx_list}
+        self._log_enable = log_enable
+
+        if self._log_enable:
+            self._choose_action_logger_dict = {}
+            for agent_idx in self._agent_idx_list:
+                self._choose_action_logger_dict[self._station_idx2name[agent_idx]] = Logger(tag=f'{self._station_idx2name[agent_idx]}.choose_action',
+                                                                                format_=LogFormat.none,
+                                                                                dump_folder=log_folder, dump_mode='w', extension_name='csv',
+                                                                                auto_timestamp=False)
+                self._choose_action_logger_dict[self._station_idx2name[agent_idx]].debug(
+                    ','.join(['episode', 'learning_index', 'tick', 'warehouse_name', 'eps', 'action', 'actual_action', 'reward']))
+
+    def calculate_reward(self, agent_name: str, current_ep: int, learning_rate: float):
+        return NotImplemented
+
+    def push_matrices(self, agent_name: str, matrix: dict):
+        """
+        store the cache from agents
+        """
+        for name, cache in matrix.items():
+            self._cache[agent_name][name].append(cache)
+
+    def _align_cache_by_next_state(self, agent_name: str):
+        cache = self._cache[agent_name]
+
+        cache['next_state'] = cache['state'][1:]
+        # align
+        for name, cache in cache.items():
+            if name != 'next_state' and cache:
+                cache.pop()
+
+    def pop_experience(self, agent_name: str):
+        """
+        return the experience, and clear the cache
+        """
+        cache = self._cache[agent_name]
+        experience_set = {name: cache[name] for name in ['state', 'action', 'reward', 'next_state', 'actual_action']}
+        experience_set['info'] = [{'td_error': 1e10} for _ in range(len(cache['state']))]
+        self._cache[agent_name] = defaultdict(list)
+        return experience_set
+
+    def _dump_logs(self, agent_name, current_ep, learning_rate):
+        extra = ['eps', 'port_states', 'vessel_states', 'action', 'actual_action', 'reward']
+        cache = self._cache[agent_name]
+        event_list = cache['decision_event']
+        for i in range(len(event_list)):
+            event = event_list[i]
+            max_load = str(event.action_scope.load)
+            max_discharge = str(event.action_scope.discharge)
+            log_str = ','.join([str(current_ep), str(learning_rate), str(event.tick), self._vessel_idx2name[event.vessel_idx], max_load, max_discharge])
+            for name in extra:
+                if type(cache[name][i]) == np.ndarray:
+                    log_str += ',' + ','.join([str(f) for f in cache[name][i]])
+                else:
+                    log_str += ',' + str(cache[name][i])
+            self._choose_action_logger_dict[agent_name].debug(log_str)
+
+
+class TruncateReward(RewardShaping):
+    def __init__(self, env, agent_idx_list: [int], offset: int = 100, reward_factor: float = 1.0, cost_factor: float = 1.0,
+                 shortage_factor: float = 1.0, time_decay: float = 0.97, log_folder: str = './', log_enable: bool = False):
+        super().__init__(env, log_folder=log_folder, log_enable=log_enable)
+        self._agent_idx_list = agent_idx_list
+        self._offset = offset
+        self._reward_factor = reward_factor
+        self._shortage_factor = shortage_factor
+        self._cost_factor = cost_factor
+        self._time_decay_factor = time_decay
+
+    def calculate_reward(self, agent_name, current_ep, learning_rate):
+        cache = self._cache[agent_name]
+        snapshot_list = self._env.snapshot_list
+        for i, tick in enumerate(cache['action_tick']):
+            start_tick = tick + 1
+            end_tick = tick + self._offset
+            
+            #calculate tc reward
+            decay_list = [self._time_decay_factor ** i for i in range(end_tick - start_tick)
+                      for _ in range(len(self._agent_idx_list))]
+
+            
+            fulfillments = snapshot_list.static_nodes[list(range(start_tick, end_tick)):self._agent_idx_list:('fulfillment', 0)]
+            tot_fulfillment = np.dot(fulfillments, decay_list)
+
+            shortages = snapshot_list.static_nodes[list(range(start_tick, end_tick)):self._agent_idx_list:("shortage", 0)]
+            tot_shortage = np.dot(shortages, decay_list)
+
+            costs = snapshot_list.static_nodes[list(range(start_tick, end_tick)):self._agent_idx_list:("extra_cost", 0)]
+            tot_cost = np.dot(costs, decay_list)
+
+            cache['reward'].append(np.float32(self._reward_factor * (tot_fulfillment - self._shortage_factor * tot_shortage
+                                              - self._cost_factor * tot_cost)))
+
+        self._align_cache_by_next_state(agent_name)
+
+        if self._log_enable:
+            self._dump_logs(agent_name, current_ep, learning_rate)

--- a/examples/hello_world/logistics/q_learning/common/state_shaping.py
+++ b/examples/hello_world/logistics/q_learning/common/state_shaping.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+from datetime import datetime
+import os
+
+import numpy as np
+import torch
+
+from maro.simulator import Env
+from maro.utils import Logger, LogFormat
+
+
+
+class StateShaping():
+    def __init__(self,
+                 env: Env,
+                 relative_tick_list: [int],
+                 warehouse_attribute_list: [str]):
+        self._env = env
+        self._relative_tick_list = relative_tick_list
+        self._warehouse_attribute_list = warehouse_attribute_list
+        self._dim = (len(self._relative_tick_list) + 1) * \
+            len(self._warehouse_attribute_list)
+
+    def __call__(self, cur_tick: int, cur_warehouse_idx: int):
+        ticks = [cur_tick] + [cur_tick + rt for rt in self._relative_tick_list]
+        warehouse_features = self._env.snapshot_list.static_nodes[ticks: [cur_warehouse_idx]: (self._warehouse_attribute_list, 0)]
+        return warehouse_features
+
+    @property
+    def dim(self):
+        return self._dim

--- a/examples/hello_world/logistics/single_host_mode/config.yml
+++ b/examples/hello_world/logistics/single_host_mode/config.yml
@@ -1,0 +1,50 @@
+experiment_name: "baseline"
+env:
+  scenario: "logistics"
+  topology: "inventory_placement"
+  max_tick: 28
+train:
+  max_ep: 10000 # max episode
+  batch_num: 10
+  batch_size: 128
+  min_train_experience_num: 1024 # when experience number is less than it, will not trigger train
+  reward_shaping: 'tc'
+  dqn:
+    target_update_frequency: 5 # target network update frequency
+    dropout_p: 0.0 # dropout parameter
+    gamma: 0.0 # reward decay
+    tau: 0.1 # soft update
+    lr: 0.05 # learning rate
+  exploration:
+    max_eps: 0.4 # max epsilon
+    phase_split_point: 0.5 # exploration two phase split point
+    first_phase_reduce_proportion: 0.8 # first phase reduce proportion of max_eps 
+  seed: 1024
+test:
+  max_ep: 3 # max episode
+  seed: 2048
+qnet:
+  seed: 0
+log:
+  runner:
+    enable: true
+  agent:
+    enable: false
+  dqn:
+    enable: false
+    dropout_p: 0.95
+  qnet:
+    enable: false
+  dashboard:
+    enable: false
+dashboard:
+  enable: false
+  influxdb:
+    host: localhost
+    port: 50301
+    use_udp: true
+    udp_port: 50304
+  ranklist:
+    enable: false
+    author: your_name
+    commit: your_commit

--- a/examples/hello_world/logistics/single_host_mode/runner.py
+++ b/examples/hello_world/logistics/single_host_mode/runner.py
@@ -1,0 +1,309 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+import io
+import os
+import random
+import numpy as np
+import torch
+import yaml
+import time
+
+import maro.simulator.utils.random as sim_random
+from tqdm import tqdm
+from collections import OrderedDict
+from datetime import datetime
+from maro.simulator import Env
+from maro.utils import SimpleExperiencePool, Logger, LogFormat, convert_dottable
+
+from examples.hello_world.logistics.q_learning.common.agent import Agent
+from examples.hello_world.logistics.q_learning.common.dqn import QNet, DQN
+from examples.hello_world.logistics.q_learning.common.reward_shaping import TruncateReward
+from examples.hello_world.logistics.q_learning.common.state_shaping import StateShaping
+from examples.hello_world.logistics.q_learning.common.action_shaping import DiscreteActionShaping
+
+
+####################################################### START OF INITIAL_PARAMETERS #######################################################
+
+CONFIG_PATH = os.environ.get('CONFIG') or 'config.yml'
+
+with io.open(CONFIG_PATH, 'r') as in_file:
+    raw_config = yaml.safe_load(in_file)
+    config = convert_dottable(raw_config)
+
+LOG_FOLDER = os.path.join(os.getcwd(), 'log', f"{datetime.now().strftime('%Y%m%d')}", config.experiment_name)
+if not os.path.exists(LOG_FOLDER):
+    os.makedirs(LOG_FOLDER)
+
+with io.open(os.path.join(LOG_FOLDER, 'config.yml'), 'w', encoding='utf8') as out_file:
+    yaml.safe_dump(raw_config, out_file)
+
+EXPERIMENT_NAME = config.experiment_name
+SCENARIO = config.env.scenario
+TOPOLOGY = config.env.topology
+MAX_TICK = config.env.max_tick
+MAX_TRAIN_EP = config.train.max_ep
+MAX_TEST_EP = config.test.max_ep
+MAX_EPS = config.train.exploration.max_eps
+PHASE_SPLIT_POINT = config.train.exploration.phase_split_point  # exploration two phase split point
+FIRST_PHASE_REDUCE_PROPORTION = config.train.exploration.first_phase_reduce_proportion  # first phase reduce proportion of max_eps
+TARGET_UPDATE_FREQ = config.train.dqn.target_update_frequency
+LEARNING_RATE = config.train.dqn.lr
+DROPOUT_P = config.train.dqn.dropout_p
+GAMMA = config.train.dqn.gamma  # Reward decay
+TAU = config.train.dqn.tau  # Soft update
+BATCH_NUM = config.train.batch_num
+BATCH_SIZE = config.train.batch_size
+MIN_TRAIN_EXP_NUM = config.train.min_train_experience_num  # when experience num is less than this num, agent will not train model
+TRAIN_SEED = config.train.seed
+TEST_SEED = config.test.seed
+QNET_SEED = config.qnet.seed
+RUNNER_LOG_ENABLE = config.log.runner.enable
+AGENT_LOG_ENABLE = config.log.agent.enable
+DQN_LOG_ENABLE = config.log.dqn.enable
+DQN_LOG_DROPOUT_P = config.log.dqn.dropout_p
+QNET_LOG_ENABLE = config.log.qnet.enable
+
+if config.train.reward_shaping not in {'tc'}:
+    raise ValueError('Unsupported reward shaping. Currently supported reward shaping types: "tc"')
+
+REWARD_SHAPING = config.train.reward_shaping
+
+# Config for dashboard
+DASHBOARD_ENABLE = config.dashboard.enable
+DASHBOARD_LOG_ENABLE = config.log.dashboard.enable
+DASHBOARD_HOST = config.dashboard.influxdb.host
+DASHBOARD_PORT = config.dashboard.influxdb.port
+DASHBOARD_USE_UDP = config.dashboard.influxdb.use_udp
+DASHBOARD_UDP_PORT = config.dashboard.influxdb.udp_port
+RANKLIST_ENABLE = config.dashboard.ranklist.enable
+AUTHOR = config.dashboard.ranklist.author
+COMMIT = config.dashboard.ranklist.commit
+
+
+####################################################### END OF INITIAL_PARAMETERS #######################################################
+
+
+class Runner:
+    def __init__(self, scenario: str, topology: str, max_tick: int, max_train_ep: int, max_test_ep: int,
+                 eps_list: [float], log_enable: bool = True):
+
+        # Init for dashboard
+        self._scenario = scenario
+        self._topology = topology
+        self._max_train_ep = max_train_ep
+        self._max_test_ep = max_test_ep
+        self._max_tick = max_tick
+        self._eps_list = eps_list
+        self._log_enable = log_enable
+        self._set_seed(TRAIN_SEED)
+        self._env = Env(scenario, topology, max_tick = max_tick)
+        self._warehouse_idx2name = self._env.node_name_mapping['static']
+        self._agent_dict = self._load_agent(self._env.agent_idx_list)
+        self._warehouse_name2idx = {}
+        for idx in self._warehouse_idx2name.keys():
+            self._warehouse_name2idx[self._warehouse_idx2name[idx]] = idx
+        self._time_cost = OrderedDict()
+        if log_enable:
+            self._logger = Logger(tag='runner', 
+                                  format_=LogFormat.simple,
+                                  dump_folder=LOG_FOLDER, 
+                                  dump_mode='w', 
+                                  auto_timestamp=False)
+            self._performance_logger = Logger(tag=f'runner.performance', 
+                                              format_=LogFormat.none,
+                                              dump_folder=LOG_FOLDER, 
+                                              dump_mode='w', 
+                                              extension_name='csv',
+                                              auto_timestamp=False)
+
+
+    def _load_agent(self, agent_idx_list: [int]):
+        self._dashboard = None
+        self._set_seed(QNET_SEED)
+        agent_dict = {}
+        state_shaping = StateShaping(env=self._env,
+                                     relative_tick_list=[-1, -2, -3, -4, -5, -6, -7],
+                                     warehouse_attribute_list=['weekday', 'stock', 'demand', 'fulfilled', 'unfulfilled'])
+        action_space = list(range(11))
+        action_shaping = DiscreteActionShaping(action_space=action_space)
+        
+        if REWARD_SHAPING == 'tc':
+            reward_shaping = TruncateReward(env=self._env, agent_idx_list=agent_idx_list, log_folder=LOG_FOLDER)
+        else:
+            raise ValueError('Unsupported Reward Shaping')
+
+        for agent_idx in agent_idx_list:
+            experience_pool = SimpleExperiencePool()
+            policy_net = QNet(name=f'{self._warehouse_idx2name[agent_idx]}.policy', 
+                              input_dim=state_shaping.dim,
+                              hidden_dims=[256, 128, 64], 
+                              output_dim=len(action_space), 
+                              dropout_p=DROPOUT_P,
+                              log_folder=LOG_FOLDER if QNET_LOG_ENABLE else None)
+            target_net = QNet(name=f'{self._warehouse_idx2name[agent_idx]}.target', 
+                              input_dim=state_shaping.dim,
+                              hidden_dims=[256, 128, 64], 
+                              output_dim=len(action_space), 
+                              dropout_p=DROPOUT_P,
+                              log_folder=LOG_FOLDER if QNET_LOG_ENABLE else None)
+            target_net.load_state_dict(policy_net.state_dict())
+            dqn = DQN(policy_net=policy_net, 
+                      target_net=target_net,
+                      gamma=GAMMA, 
+                      tau=TAU, 
+                      target_update_frequency=TARGET_UPDATE_FREQ, 
+                      lr=LEARNING_RATE,
+                      log_folder=LOG_FOLDER if DQN_LOG_ENABLE else None, 
+                      log_dropout_p=DQN_LOG_DROPOUT_P,
+                      dashboard=self._dashboard)
+            agent_dict[agent_idx] = Agent(agent_name=self._warehouse_idx2name[agent_idx],
+                                          algorithm=dqn, 
+                                          experience_pool=experience_pool,
+                                          state_shaping=state_shaping,
+                                          action_shaping=action_shaping,
+                                          reward_shaping=reward_shaping,
+                                          batch_num=BATCH_NUM, 
+                                          batch_size=BATCH_SIZE,
+                                          min_train_experience_num=MIN_TRAIN_EXP_NUM,
+                                          log_folder=LOG_FOLDER if AGENT_LOG_ENABLE else None,
+                                          dashboard=self._dashboard)
+
+        return agent_dict
+
+    def start(self):
+        pbar = tqdm(range(self._max_train_ep))
+
+        for ep in pbar:
+            time_dict = OrderedDict()
+            ep_start = time.time()
+            self._set_seed(TRAIN_SEED + ep)
+            pbar.set_description('train episode')
+            env_start = time.time()
+            _, decision_event, is_done = self._env.step(None)
+
+            while not is_done:
+                action = self._agent_dict[decision_event.warehouse_idx].choose_action(
+                        decision_event=decision_event, eps=self._eps_list[ep], current_ep=ep, snapshot_list= self._env.snapshot_list)
+                _, decision_event, is_done = self._env.step(action)
+                
+            time_dict['env_time'] = time.time() - env_start
+            time_dict['train_time'] = 0
+            for agent in self._agent_dict.values():
+                train_start = time.time()
+                agent.store_experience(current_ep=ep)
+                train_start = time.time()
+                agent.train(current_ep=ep)
+                time_dict[agent._agent_name] = time.time() - train_start
+                time_dict['train_time'] += time_dict[agent._agent_name]
+
+            if self._log_enable:
+                self._print_summary(ep=ep, is_train=True)
+
+            self._env.reset()
+
+            time_dict['ep_time'] = time.time() - ep_start
+            time_dict['other_time'] = time_dict['ep_time'] - time_dict['train_time'] - time_dict['env_time']
+            self._time_cost[ep] = time_dict
+
+        self._test()
+
+    def _test(self):
+        pbar = tqdm(range(self._max_test_ep))
+        for ep in pbar:
+            time_dict = OrderedDict()
+            ep_start = time.time()
+            self._set_seed(TEST_SEED)
+            pbar.set_description('test episode')
+            env_start = time.time()
+            _, decision_event, is_done = self._env.step(None)
+            tot_reward = 0
+            while not is_done:
+                action = self._agent_dict[decision_event.warehouse_idx].choose_action(
+                    decision_event=decision_event, 
+                    eps=self._eps_list[ep], 
+                    current_ep=ep, 
+                    snapshot_list=self._env.snapshot_list)
+                reward, decision_event, is_done = self._env.step(action)
+                tot_reward += reward or 0
+        
+            print("Cumulative Reward: {}".format(tot_reward))
+            time_dict['env_time'] = time.time() - env_start
+            if self._log_enable:
+                self._print_summary(ep=ep, is_train=False)
+
+            self._env.reset()
+
+            time_dict['ep_time'] = time.time() - ep_start
+            time_dict['other_time'] = time_dict['ep_time'] - time_dict['env_time']
+            self._time_cost[ep + self._max_train_ep] = time_dict
+
+    def _print_summary(self, ep, is_train: bool = True):
+        stock_list = self._env.snapshot_list.static_nodes[
+                        self._env.tick: self._env.agent_idx_list: ('stock', 0)]
+        pretty_stock_dict = OrderedDict()
+        tot_stock = 0
+        for i, stock in enumerate(stock_list):
+            pretty_stock_dict[self._warehouse_idx2name[i]] = stock
+            tot_stock += stock
+        pretty_stock_dict['total_stock'] = tot_stock
+
+        demand_list = self._env.snapshot_list.static_nodes[
+                       self._env.tick: self._env.agent_idx_list: ('demand', 0)]
+        pretty_demand_dict = OrderedDict()
+        tot_demand = 0
+        for i, demand in enumerate(demand_list):
+            pretty_demand_dict[self._warehouse_idx2name[i]] = demand
+            tot_demand += demand
+        pretty_demand_dict['total_demand'] = tot_demand
+
+        if is_train:
+            self._performance_logger.debug(
+                f"{ep},{self._eps_list[ep]},{','.join([str(value) for value in pretty_demand_dict.values()])},{','.join([str(value) for value in pretty_stock_dict.values()])}")
+            self._logger.critical(
+                f'{self._env.name} | train | [{ep + 1}/{self._max_train_ep}] total tick: {self._max_tick}, total demand: {pretty_demand_dict}, total stock: {pretty_stock_dict}')
+        else:
+            self._logger.critical(
+                f'{self._env.name} | test | [{ep + 1}/{self._max_test_ep}] total tick: {self._max_tick}, total demand: {pretty_demand_dict}, total stock: {pretty_stock_dict}')
+
+        if self._dashboard is not None:
+            self._send_to_dashboard(ep, pretty_stock_dict, pretty_demand_dict, is_train)
+
+    def _set_seed(self, seed):
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+        np.random.seed(seed)
+        random.seed(seed)
+        sim_random.seed(seed)
+
+
+if __name__ == '__main__':
+    phase_split_point = PHASE_SPLIT_POINT
+    first_phase_eps_delta = MAX_EPS * FIRST_PHASE_REDUCE_PROPORTION
+    first_phase_total_ep = MAX_TRAIN_EP * phase_split_point
+    second_phase_eps_delta = MAX_EPS * (1 - FIRST_PHASE_REDUCE_PROPORTION)
+    second_phase_total_ep = MAX_TRAIN_EP * (1 - phase_split_point)
+
+    first_phase_eps_step = first_phase_eps_delta / (first_phase_total_ep + 1e-10)
+    second_phase_eps_step = second_phase_eps_delta / (second_phase_total_ep - 1 + 1e-10)
+
+    eps_list = []
+    for i in range(MAX_TRAIN_EP):
+        if i < first_phase_total_ep:
+            eps_list.append(MAX_EPS - i * first_phase_eps_step)
+        else:
+            eps_list.append(MAX_EPS - first_phase_eps_delta - (i - first_phase_total_ep) * second_phase_eps_step)
+
+    eps_list[-1] = 0.0
+
+    runner = Runner(scenario=SCENARIO, 
+                    topology=TOPOLOGY,
+                    max_tick=MAX_TICK, 
+                    max_train_ep=MAX_TRAIN_EP,
+                    max_test_ep=MAX_TEST_EP, 
+                    eps_list=eps_list,
+                    log_enable=RUNNER_LOG_ENABLE)
+
+    runner.start()

--- a/examples/hello_world/logistics/single_host_mode/silent_run.sh
+++ b/examples/hello_world/logistics/single_host_mode/silent_run.sh
@@ -1,0 +1,1 @@
+LOG_LEVEL=PROGRESS python runner.py

--- a/maro/simulator/scenarios/logistics/business_engine.py
+++ b/maro/simulator/scenarios/logistics/business_engine.py
@@ -1,37 +1,47 @@
 import os
 from enum import IntEnum
 from typing import List, Dict
+
+import numpy as np
+from yaml import safe_load
+
 from maro.simulator.frame import Frame, SnapshotList, FrameAttributeType, FrameNodeType
 from maro.simulator.event_buffer import Event, EventBuffer, DECISION_EVENT
 from maro.simulator.scenarios import AbsBusinessEngine
 from maro.simulator.scenarios.entity_base import FrameBuilder
 from .warehouse import Warehouse
-from .common import Action, Demand
-from yaml import safe_load
+from .common import Action, Demand, DecisionEvent
+
 
 STATIC_NODE = FrameNodeType.STATIC
-
 WAREHOUSE_NUMBER = 1
+
 
 class LogisticsType(IntEnum):
     DemandRequirement = 1  # 
+
 
 class LogisticsBusinessEngine(AbsBusinessEngine):
     def __init__(self, event_buffer: EventBuffer, config_path: str, start_tick: int, max_tick: int, frame_resolution: int):
         super().__init__(event_buffer, config_path, start_tick, max_tick, frame_resolution)
 
-        # these 4 items will update from configuration file
-        self._max_order = 0
-        self._max_capacity = 0
-        self._demand_step = 1
+        # these items will update from configuration file
         self._init_stock = 0
+        self._max_order = 10
+        self._max_capacity = 100
+        self._min_demand = 0
+        self._max_demand = 10
+        self._min_demand_noise = -1
+        self._max_demand_noise = 1
+        self._unit_cost = 1
+        self._unit_price = 2
+        self._storage_cost = 0.5
 
+        self._profit = 0  # used for calculating reward
         self._frame: Frame = None
         self._snapshot_list: SnapshotList = None
         self._warehouses = []
         self._conf = {}
-
-        self._cur_demand = 0 # used to hold current demand for reward function
 
         self._init_config()
         self._register_events()
@@ -40,13 +50,11 @@ class LogisticsBusinessEngine(AbsBusinessEngine):
     ###### minimum functions inherit from AbsBusinessEngine, other functions can be override depend on requirements ########
 
     def step(self, tick: int) -> bool:
-        demand_number = self.demand(tick) # generate a demand by tick
-        self._cur_demand = demand_number
+        demand_value = self.demand(tick) # generate a demand by tick
 
         # generate and insert an event
         # though the event's payload can be any object, here we just use the demand number as payload
-        demand_evt = self._event_buffer.gen_atom_event(tick, LogisticsType.DemandRequirement, payload=Demand(demand_number))
-
+        demand_evt = self._event_buffer.gen_atom_event(tick, LogisticsType.DemandRequirement, payload=Demand(demand_value))
         self._event_buffer.insert_event(demand_evt)
 
         # NOTE: we can stop the simulator at step and post_step
@@ -62,8 +70,7 @@ class LogisticsBusinessEngine(AbsBusinessEngine):
         # so we check it here
 
         # shall we stop after processed all the event?
-        stock = self._warehouses[0].stock
-        is_done = stock < 0 or stock > self._max_capacity
+        is_done = not all([0 <= w.stock <= w.max_capacity for w in self._warehouses])
 
         # let's take the snapshot, as env will not take snapshot at end (only before take action),
         # then we can see the value changes
@@ -72,8 +79,8 @@ class LogisticsBusinessEngine(AbsBusinessEngine):
         return is_done
 
     def rewards(self, actions):
-        # ignore actions, just return current demand as rewards
-        return [self._cur_demand] # our reward must be a list for now
+        # ignore actions, just return recorded profit
+        return [self._profit] # our reward must be a list for now
 
     @property
     def frame(self) -> Frame:
@@ -83,12 +90,24 @@ class LogisticsBusinessEngine(AbsBusinessEngine):
     def snapshots(self) -> SnapshotList:
         return self._snapshot_list
 
+    def get_node_name_mapping(self) -> dict:
+        """
+        Get node name mappings related with this environment
+
+        Returns:
+            Node index to name mapping dictionary
+            {
+                "static": {index: name}
+            }
+        """
+        return dict(static={w.index: w.name for w in self._warehouses})
+
     def get_agent_idx_list(self) -> List[int]:
-        """Get port index list related with this environment
+        """Get warehouse index list related with this environment
         Returns:
             List[int]: list of port index
         """
-        return [i for i in range(len(self._warehouses))]
+        return list(range(len(self._warehouses)))
 
     def reset(self):
         # reset frame will clear the value of stock to 0, so we need to reset warehouse here
@@ -101,7 +120,10 @@ class LogisticsBusinessEngine(AbsBusinessEngine):
     ###### private functions ######
 
     def demand(self, tick: int):
-        return tick % self._demand_step # TODO: catch the exception
+        weekday_trend = (np.cos((tick % 7) * 2 * np.pi / 7) + 1) / 2
+        scaled = (self._max_demand - self._min_demand) * weekday_trend + self._min_demand
+        noise = np.random.randint(self._min_demand_noise, self._max_demand_noise + 1)
+        return np.maximum(0, int(scaled) + noise)
 
     def _register_events(self):
         self._event_buffer.register_event_handler(LogisticsType.DemandRequirement, self._on_demand_requirement)
@@ -109,16 +131,23 @@ class LogisticsBusinessEngine(AbsBusinessEngine):
 
     def _init_frame(self):
         # only build the frame with static node (Warehouse)
-        self._frame = FrameBuilder.new() \
-            .add_model(Warehouse, WAREHOUSE_NUMBER) \
-            .build() # how many agents = 1
+        self._frame = (FrameBuilder
+                       .new()
+                       .add_model(Warehouse, WAREHOUSE_NUMBER)
+                       .build())  # how many agents = 1
 
         # create our snapshot_list, and specified how many snapshots we can take
         self._snapshot_list = SnapshotList(self._frame, self._max_tick)
 
         # create warehouse instance to acess
-        for i in range(WAREHOUSE_NUMBER):
-            self._warehouses.append(Warehouse(i, self._init_stock, self._max_capacity, self._frame))
+        self._warehouses = [
+            Warehouse(
+                index=i,
+                initial_stock=self._init_stock,
+                max_capacity=self._max_capacity,
+                frame=self._frame
+            ) for i in range(WAREHOUSE_NUMBER)
+        ]
 
         # this would read recorded data for playback
 
@@ -126,27 +155,43 @@ class LogisticsBusinessEngine(AbsBusinessEngine):
         with open(os.path.join(self._config_path, "config.yml")) as fp:
             self._conf = safe_load(fp)
 
-            self._max_order = self._conf["max_order"]
-            self._max_capacity = self._conf["max_capacity"]
-            self._demand_step = self._conf["demand_step"]
-            self._init_stock = self._conf["init_stock"]
+        self._max_order = self._conf["max_order"]
+        self._max_capacity = self._conf["max_capacity"]
+        self._init_stock = self._conf["init_stock"]
+        self._min_demand = self._conf["min_demand"]
+        self._max_demand = self._conf["max_demand"]
+        self._min_demand_noise = self._conf["min_demand_noise"]
+        self._max_demand_noise = self._conf["max_demand_noise"]
+        self._unit_cost = self._conf["unit_cost"]
+        self._unit_price = self._conf["unit_price"]
+        self._storage_cost = self._conf["storage_cost"]
+
+    def _action_scope(self, index, event_type=None):
+        return {w.index: self._max_order for w in self._warehouses}
 
     def _on_demand_requirement(self, evt: Event):
         demand: Demand = evt.payload
 
-        self._warehouses[0].fulfill_demand(demand.demand)
-
-        stock = self._warehouses[0].stock
-
-        if stock >=0 and stock<= self._max_capacity:
-            # TODO: we need an action each tick?
-            # for this demo, we do not need any payload for decision event
-            decision_evt = self._event_buffer.gen_cascade_event(evt.tick, DECISION_EVENT, None)
-
-            self._event_buffer.insert_event(decision_evt)
+        for warehouse in self._warehouses:
+            warehouse.fulfill_demand(evt.tick, demand.demand)
+            if 0 <= warehouse.stock <= warehouse.max_capacity:
+                # create payload for decision event
+                decision_event = DecisionEvent(evt.tick, warehouse.index, self.snapshots, self._action_scope)
+                event = self._event_buffer.gen_cascade_event(evt.tick, DECISION_EVENT, payload=decision_event)
+                self._event_buffer.insert_event(event)
 
     def _on_action_recieved(self, evt: Event):
         # here we recieved actions (Env will wrapper actions into a list, even only one action)
-        action: Action = evt.payload[0]
+        actions: Action = evt.payload
 
-        self._warehouses[0].supply_stock(action.restock)
+        # restock warehouses and calculate profit
+        profit = 0
+        for action in actions:
+            warehouse = self._warehouses[action.warehouse_idx]
+            warehouse.supply_stock(action.restock)
+            profit += warehouse.fulfilled * self._unit_price
+            profit -= warehouse.unfulfilled * self._unit_price
+            profit -= warehouse.stock * self._storage_cost 
+            profit -= action.restock * self._unit_cost
+
+        self._profit = profit

--- a/maro/simulator/scenarios/logistics/common.py
+++ b/maro/simulator/scenarios/logistics/common.py
@@ -1,3 +1,8 @@
+from typing import Callable
+from maro.simulator.frame import SnapshotList
+
+
+
 class Demand:
     def __init__(self, demand: int):
         self.demand = demand
@@ -5,9 +10,40 @@ class Demand:
     def __repr__(self):
         return f"(Demand value: {self.demand})"
 
+
 class Action:
-    def __init__(self, restock: int):
+    def __init__(self, warehouse_idx: int, restock: int):
+        self.warehouse_idx = warehouse_idx
         self.restock = restock
 
     def __repr__(self):
         return f"Action(restock: {self.restock})"
+
+
+class ActionScope:
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return f'ActionScope'
+
+
+class DecisionEvent:
+    def __init__(self, tick:int, warehouse_idx:int, snapshot_list: SnapshotList, action_scope_func: Callable):
+        self.tick = tick
+        self.warehouse_idx = warehouse_idx
+        self.snapshot_list = snapshot_list
+        
+        self._action_scope_func = action_scope_func
+        self._action_scope = None
+
+    @property
+    def action_scope(self):
+        # NOTE: we use a function call instead of value to make sure the agent can always get latest states
+        if self._action_scope is None:
+            self._action_scope = self._action_scope_func(self.warehouse_idx)
+        
+        return self._action_scope

--- a/maro/simulator/scenarios/logistics/topologies/inventory_placement/config.yml
+++ b/maro/simulator/scenarios/logistics/topologies/inventory_placement/config.yml
@@ -1,0 +1,10 @@
+init_stock: 0
+max_order: 10
+max_capacity: 100
+min_demand: 0
+max_demand: 10
+min_demand_noise: -1
+max_demand_noise: 1
+unit_cost: 1
+unit_price: 2
+storage_cost: 0.5

--- a/maro/simulator/scenarios/logistics/topologies/sample/config.yml
+++ b/maro/simulator/scenarios/logistics/topologies/sample/config.yml
@@ -1,5 +1,0 @@
-init_stock: 1
-max_order: 5
-max_capacity: 15
-
-demand_step: 3

--- a/maro/simulator/scenarios/logistics/warehouse.py
+++ b/maro/simulator/scenarios/logistics/warehouse.py
@@ -1,25 +1,37 @@
 from maro.simulator.frame import Frame, FrameNodeType
 from maro.simulator.scenarios.entity_base import EntityBase, IntAttribute, FloatAttribute, frame_node
 
+
 static_node = FrameNodeType.STATIC
+
 
 @frame_node(static_node)
 class Warehouse(EntityBase):
-    # this will register 2 int attributes in Frame, and same with previous property definition
+    # this will register int attributes in Frame, and same with previous property definition
+    weekday = IntAttribute()
     stock = IntAttribute()
     demand = IntAttribute()
+    fulfilled = IntAttribute()
+    unfulfilled = IntAttribute()
 
-    def __init__(self, index: int, stock:int, capacity:int, frame: Frame):
+    def __init__(self, index: int, initial_stock: int, max_capacity: int, frame: Frame):
         super().__init__(frame, index)
-        self._stock = stock # initial state
-        self.capacity = capacity # this is not a frame attribute, so will not save into frame
+        self.index = index
+        self.name = "warehouse_{}".format(index)
+        self._initial_stock = initial_stock # initial state
+        self.max_capacity = max_capacity # this is not a frame attribute, so will not save into frame
 
-
-    def fulfill_demand(self, value: int):
-        self.stock -= value
+    def fulfill_demand(self, tick: int, value: int):
+        self.weekday = tick % 7
+        self.demand = value
+        self.fulfilled = min(self.stock, value)
+        self.unfulfilled = max(0, value - self.stock)
+        self.stock -= self.fulfilled
 
     def supply_stock(self, value: int):
         self.stock += value
 
     def reset(self):
-        self.stock = self._stock
+        self.stock = self._initial_stock
+        self.fulfilled = 0
+        self.unfulfilled = 0


### PR DESCRIPTION
- updated instructions in readme to build dashboard/resource.tar.gz which is needed by setup.py (also added this file to .gitignore)
- extended logistics business engine to support noisy sinusoidal demand and multiple warehouses
- added profit based reward function calculation
- added dqn trainer for logistics example

Minor Issues: 
- I could not get maro/simulator/scenarios/finance/reader/reader.c to compile due to line 3899 (so I commented that out locally)
- I found it easier to use `pip install -e . --verbose` vs `build_maro.sh` due to some errors and also so that changes to code are reflected when running python scripts

Major Issues:
- Current DQN implementation for logistics does not seem to be converging towards higher reward. I'm not sure if this is due to a problem in the state shaping or how the frame attributes are passed to the decision event? 
@chaosyu101 and @eisber can you review this and comment on what I might be doing wrong?
