### PR TITLE
switch the key and value of handler_dict in decorator

### DIFF
--- a/maro/communication/dist_decorator.py
+++ b/maro/communication/dist_decorator.py
@@ -40,12 +40,12 @@ def dist(proxy: Proxy, handler_dict: {object: Callable}):
 
             def launch(self):
                 """Universal entry point for running a ``cls`` instance in distributed mode."""
-                for msg in self.proxy.receive():
-                    self._registry_table.push(msg)
+                for message in self.proxy.receive():
+                    self._registry_table.push(message)
                     triggered_event = self._registry_table.get()
 
-                    for handler_fun, msg_lst in triggered_event:
-                        self._handler_function[handler_fun](msg_lst)
+                    for handler_fun, message_list in triggered_event:
+                        self._handler_function[handler_fun](message_list)
 
         return Wrapper
 

--- a/maro/communication/dist_decorator.py
+++ b/maro/communication/dist_decorator.py
@@ -28,7 +28,7 @@ def dist(proxy: Proxy, handler_dict: {object: Callable}):
                 self._registry_table = RegisterTable(self.proxy.get_peers())
                 # Use functools.partial to freeze handling function's local_instance and proxy
                 # arguments to self.local_instance and self.proxy.
-                for handler_fn, constraint in handler_dict.items():
+                for constraint, handler_fn in handler_dict.items():
                     self._handler_function[handler_fn] = partial(handler_fn, self.local_instance, self.proxy)
                     self._registry_table.register_event_handler(constraint, handler_fn)
 

--- a/maro/communication/dist_decorator.py
+++ b/maro/communication/dist_decorator.py
@@ -25,7 +25,7 @@ def dist(proxy: Proxy, handler_dict: {object: Callable}):
                 self.local_instance = cls(*args, **kwargs)
                 self.proxy = proxy
                 self._handler_function = {}
-                self._registry_table = RegisterTable(self.proxy.get_peers())
+                self._registry_table = RegisterTable(self.proxy.get_peers)
                 # Use functools.partial to freeze handling function's local_instance and proxy
                 # arguments to self.local_instance and self.proxy.
                 for constraint, handler_fn in handler_dict.items():

--- a/maro/communication/dist_decorator.py
+++ b/maro/communication/dist_decorator.py
@@ -28,9 +28,9 @@ def dist(proxy: Proxy, handler_dict: {object: Callable}):
                 self._registry_table = RegisterTable(self.proxy.get_peers)
                 # Use functools.partial to freeze handling function's local_instance and proxy
                 # arguments to self.local_instance and self.proxy.
-                for constraint, handler_fn in handler_dict.items():
-                    self._handler_function[handler_fn] = partial(handler_fn, self.local_instance, self.proxy)
-                    self._registry_table.register_event_handler(constraint, handler_fn)
+                for constraint, handler_fun in handler_dict.items():
+                    self._handler_function[handler_fun] = partial(handler_fun, self.local_instance, self.proxy)
+                    self._registry_table.register_event_handler(constraint, handler_fun)
 
             def __getattr__(self, name):
                 if name in self.__dict__:
@@ -44,8 +44,8 @@ def dist(proxy: Proxy, handler_dict: {object: Callable}):
                     self._registry_table.push(msg)
                     triggered_event = self._registry_table.get()
 
-                    for handler_fn, msg_lst in triggered_event:
-                        self._handler_function[handler_fn](msg_lst)
+                    for handler_fun, msg_lst in triggered_event:
+                        self._handler_function[handler_fun](msg_lst)
 
         return Wrapper
 

--- a/tests/communication/test_decorator.py
+++ b/tests/communication/test_decorator.py
@@ -35,18 +35,18 @@ class TestDecorator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         print(f"The dist decorator unit test start!")
-        # Prepare Redis.
+        # Initial Redis.
         redis_port = get_random_port()
         cls.redis_process = subprocess.Popen(["redis-server", "--port", str(redis_port), "--daemonize yes"])
         cls.redis_process.wait()
 
-        # Start decorator
+        # Initial receiver.
         conditional_event = "sender:*:1"
         handler_dict = {conditional_event: handler_function}
         decorator_task = threading.Thread(target=lunch_receiver, args=(handler_dict, redis_port, ))
         decorator_task.start()
 
-        # Prepare proxy.
+        # Initial sender proxy.
         with ThreadPoolExecutor() as executor:
             sender_task = executor.submit(proxy_generator, "sender", redis_port)
             cls.sender_proxy = sender_task.result()

--- a/tests/communication/test_decorator.py
+++ b/tests/communication/test_decorator.py
@@ -18,7 +18,9 @@ def handler_function(that, proxy, message):
     sys.exit(0)
 
 
-def lunch_receiver(proxy, handler_dict):
+def lunch_receiver(handler_dict, redis_port):
+    proxy = proxy_generator("receiver", redis_port)
+
     @dist(proxy, handler_dict)
     class Receiver:
         def __init__(self):
@@ -38,23 +40,16 @@ class TestDecorator(unittest.TestCase):
         cls.redis_process = subprocess.Popen(["redis-server", "--port", str(redis_port), "--daemonize yes"])
         cls.redis_process.wait()
 
-        # Prepare proxy.
-        proxy_type_list = ["receiver", "sender"]
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            all_task = [executor.submit(proxy_generator, proxy_type, redis_port) for proxy_type in proxy_type_list]
-
-            for task in as_completed(all_task):
-                result = task.result()
-                if "receiver" in result.component_name:
-                    cls.receiver_proxy = result
-                else:
-                    cls.sender_proxy = result
-
         # Start decorator
         conditional_event = "sender:*:1"
         handler_dict = {conditional_event: handler_function}
-        decorator_task = threading.Thread(target=lunch_receiver, args=(cls.receiver_proxy, handler_dict,))
+        decorator_task = threading.Thread(target=lunch_receiver, args=(handler_dict, redis_port, ))
         decorator_task.start()
+
+        # Prepare proxy.
+        with ThreadPoolExecutor() as executor:
+            sender_task = executor.submit(proxy_generator, "sender", redis_port)
+            cls.sender_proxy = sender_task.result()
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -64,10 +59,10 @@ class TestDecorator(unittest.TestCase):
 
     def test_decorator(self):
         message = SessionMessage(tag="unittest",
-                                 source=self.sender_proxy.component_name,
-                                 destination=self.receiver_proxy.component_name,
+                                 source=TestDecorator.sender_proxy.component_name,
+                                 destination=TestDecorator.sender_proxy.peers["receiver"][0],
                                  payload={"counter": 0})
-        replied_message = self.sender_proxy.send(message)
+        replied_message = TestDecorator.sender_proxy.send(message)
 
         self.assertEqual(message.payload["counter"]+1, replied_message[0].payload["counter"])
 

--- a/tests/communication/test_decorator.py
+++ b/tests/communication/test_decorator.py
@@ -11,34 +11,40 @@ import threading
 import unittest
 
 from maro.communication import Proxy, SessionMessage, dist
+from utils import get_random_port
 
 
-def proxy_generator(component_type):
+def proxy_generator(component_type, redis_port):
     if component_type == "receiver":
         proxy = Proxy(group_name="proxy_unit_test",
                       component_type="receiver",
                       expected_peers={"sender": 1},
+                      redis_address=("localhost", redis_port),
                       log_enable=False)
     elif component_type == "sender":
         proxy = Proxy(group_name="proxy_unit_test",
                       component_type="sender",
                       expected_peers={"receiver": 1},
+                      redis_address=("localhost", redis_port),
                       log_enable=False)
     return proxy
 
+
 def handler_function(that, proxy, message):
-    replied_payload = message.payload + 1
+    replied_payload = {"counter": message.payload["counter"] + 1}
     proxy.reply(message, payload=replied_payload)
     sys.exit(0)
 
-def decorator_start(proxy, handler_dict):
+
+def lunch_receiver(proxy, handler_dict):
     @dist(proxy, handler_dict)
     class Receiver:
         def __init__(self):
             pass
-    
-    decorator = Receiver()
-    decorator.launch()
+
+    receiver = Receiver()
+    receiver.launch()
+
 
 @unittest.skipUnless(os.environ.get("test_with_redis", False), "require redis")
 class TestDecorator(unittest.TestCase):
@@ -46,45 +52,42 @@ class TestDecorator(unittest.TestCase):
     def setUpClass(cls):
         print(f"The dist decorator unit test start!")
         # Prepare Redis.
-        try:
-            temp_redis = redis.Redis(host="localhost", port=6379)
-            temp_redis.ping()
-        except Exception as _:
-            cls.redis_process = subprocess.Popen(['redis-server'])
-            time.sleep(1)
+        random_port = get_random_port()
+        cls.redis_process = subprocess.Popen(["redis-server", "--port", str(random_port), "--daemonize yes"])
+        cls.redis_process.wait()
 
         # Prepare proxy.
         proxy_type_list = ["receiver", "sender"]
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            all_task = [executor.submit(proxy_generator, (proxy_type)) for proxy_type in proxy_type_list]
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            all_task = [executor.submit(proxy_generator, proxy_type, random_port) for proxy_type in proxy_type_list]
 
             for task in as_completed(all_task):
-                r = task.result()
-                if "receiver" in r.component_name:
-                    cls.receiver = r
+                result = task.result()
+                if "receiver" in result.component_name:
+                    cls.receiver_proxy = result
                 else:
-                    cls.sender = r
-        
+                    cls.sender_proxy = result
+
         # Start decorator
         conditional_event = "sender:*:1"
-        handler_dict = {conditional_event:handler_function}
-        decorator_task = threading.Thread(target=decorator_start, args=(cls.receiver, handler_dict,))
+        handler_dict = {conditional_event: handler_function}
+        decorator_task = threading.Thread(target=lunch_receiver, args=(cls.receiver_proxy, handler_dict,))
         decorator_task.start()
 
     @classmethod
     def tearDownClass(cls) -> None:
         print(f"The dist decorator unit test finished!")
         if hasattr(cls, "redis_process"):
-            cls.redis_process.terminate()
+            cls.redis_process.kill()
 
     def test_decorator(self):
         message = SessionMessage(tag="unittest",
-                                 source=self.sender.component_name,
-                                 destination=self.receiver.component_name,
-                                 payload=0)
-        replied_message = self.sender.send(message)
+                                 source=self.sender_proxy.component_name,
+                                 destination=self.receiver_proxy.component_name,
+                                 payload={"counter": 0})
+        replied_message = self.sender_proxy.send(message)
 
-        self.assertEqual(1, replied_message[0].payload)
+        self.assertEqual(1, replied_message[0].payload["counter"])
 
 
 if __name__ == "__main__":

--- a/tests/communication/test_decorator.py
+++ b/tests/communication/test_decorator.py
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import os
+import redis
+import subprocess
+import sys
+import time
+import threading
+import unittest
+
+from maro.communication import Proxy, SessionMessage, dist
+
+
+def proxy_generator(component_type):
+    if component_type == "receiver":
+        proxy = Proxy(group_name="proxy_unit_test",
+                      component_type="receiver",
+                      expected_peers={"sender": 1},
+                      log_enable=False)
+    elif component_type == "sender":
+        proxy = Proxy(group_name="proxy_unit_test",
+                      component_type="sender",
+                      expected_peers={"receiver": 1},
+                      log_enable=False)
+    return proxy
+
+def handler_function(that, proxy, message):
+    replied_payload = message.payload + 1
+    proxy.reply(message, payload=replied_payload)
+    sys.exit(0)
+
+def decorator_start(proxy, handler_dict):
+    @dist(proxy, handler_dict)
+    class Receiver:
+        def __init__(self):
+            pass
+    
+    decorator = Receiver()
+    decorator.launch()
+
+@unittest.skipUnless(os.environ.get("test_with_redis", False), "require redis")
+class TestDecorator(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print(f"The dist decorator unit test start!")
+        # Prepare Redis.
+        try:
+            temp_redis = redis.Redis(host="localhost", port=6379)
+            temp_redis.ping()
+        except Exception as _:
+            cls.redis_process = subprocess.Popen(['redis-server'])
+            time.sleep(1)
+
+        # Prepare proxy.
+        proxy_type_list = ["receiver", "sender"]
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            all_task = [executor.submit(proxy_generator, (proxy_type)) for proxy_type in proxy_type_list]
+
+            for task in as_completed(all_task):
+                r = task.result()
+                if "receiver" in r.component_name:
+                    cls.receiver = r
+                else:
+                    cls.sender = r
+        
+        # Start decorator
+        conditional_event = "sender:*:1"
+        handler_dict = {conditional_event:handler_function}
+        decorator_task = threading.Thread(target=decorator_start, args=(cls.receiver, handler_dict,))
+        decorator_task.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        print(f"The dist decorator unit test finished!")
+        if hasattr(cls, "redis_process"):
+            cls.redis_process.terminate()
+
+    def test_decorator(self):
+        message = SessionMessage(tag="unittest",
+                                 source=self.sender.component_name,
+                                 destination=self.receiver.component_name,
+                                 payload=0)
+        replied_message = self.sender.send(message)
+
+        self.assertEqual(1, replied_message[0].payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/communication/test_proxy.py
+++ b/tests/communication/test_proxy.py
@@ -6,22 +6,24 @@ import redis
 import subprocess
 import time
 import unittest
-import sys
 import os
 
 from maro.communication import Proxy, SessionMessage, SessionType
+from utils import get_random_port
 
 
-def proxy_generator(component_type):
+def proxy_generator(component_type, redis_port):
     if component_type == "master":
         proxy = Proxy(group_name="proxy_unit_test",
                       component_type="master",
                       expected_peers={"worker": 5},
+                      redis_address=("localhost", redis_port),
                       log_enable=False)
     elif component_type == "worker":
         proxy = Proxy(group_name="proxy_unit_test",
                       component_type="worker",
                       expected_peers={"master": 1},
+                      redis_address=("localhost", redis_port),
                       log_enable=False)
     return proxy
 
@@ -30,6 +32,7 @@ def message_receive(proxy):
     for received_message in proxy.receive(is_continuous=False):
         return received_message.payload
 
+
 @unittest.skipUnless(os.environ.get("test_with_redis", False), "require redis")
 class TestProxy(unittest.TestCase):
 
@@ -37,39 +40,36 @@ class TestProxy(unittest.TestCase):
     def setUpClass(cls):
         print(f"The proxy unit test start!")
         # prepare Redis
-        try:
-            temp_redis = redis.Redis(host="localhost", port=6379)
-            temp_redis.ping()
-        except Exception as e:
-            cls.redis_process = subprocess.Popen(['redis-server'])
-            time.sleep(1)
+        random_port = get_random_port()
+        cls.redis_process = subprocess.Popen(["redis-server", "--port", str(random_port), "--daemonize yes"])
+        cls.redis_process.wait()
 
         # prepare proxies
-        cls.workers = []
-        proxy_type_list = ["master"] + ["worker"]*5
+        cls.worker_proxy = []
+        proxy_type_list = ["master"] + ["worker"] * 5
         with ThreadPoolExecutor(max_workers=6) as executor:
-            all_task = [executor.submit(proxy_generator, (proxy_type)) for proxy_type in proxy_type_list]
+            all_task = [executor.submit(proxy_generator, proxy_type, random_port) for proxy_type in proxy_type_list]
 
             for task in as_completed(all_task):
-                r = task.result()
-                if "master" in r.component_name:
-                    cls.master = r
+                result = task.result()
+                if "master" in result.component_name:
+                    cls.master_proxy = result
                 else:
-                    cls.workers.append(r)
+                    cls.worker_proxy.append(result)
 
     @classmethod
     def tearDownClass(cls) -> None:
         print(f"The proxy unit test finished!")
         if hasattr(cls, "redis_process"):
-            cls.redis_process.terminate()
+            cls.redis_process.kill()
 
     def test_send(self):
-        for worker in self.workers:
+        for worker in self.worker_proxy:
             send_msg = SessionMessage(tag="unit_test",
-                                      source=self.master.component_name,
+                                      source=self.master_proxy.component_name,
                                       destination=worker.component_name,
                                       payload="hello_world!")
-            self.master.isend(send_msg)
+            self.master_proxy.isend(send_msg)
 
             for receive_message in worker.receive(is_continuous=False):
                 self.assertEqual(send_msg.payload, receive_message.payload)
@@ -77,41 +77,41 @@ class TestProxy(unittest.TestCase):
     def test_scatter(self):
         scatter_payload = ["worker_1", "worker_2", "worker_3", "worker_4", "worker_5"]
         destination_payload_list = [(worker.component_name, scatter_payload[i])
-                                    for i, worker in enumerate(self.workers)]
+                                    for i, worker in enumerate(self.worker_proxy)]
 
-        self.master.iscatter(tag="unit_test",
-                             session_type=SessionType.NOTIFICATION,
-                             destination_payload_list=destination_payload_list)
+        self.master_proxy.iscatter(tag="unit_test",
+                                   session_type=SessionType.NOTIFICATION,
+                                   destination_payload_list=destination_payload_list)
 
-        for i, worker in enumerate(self.workers):
+        for i, worker in enumerate(self.worker_proxy):
             for msg in worker.receive(is_continuous=False):
                 self.assertEqual(scatter_payload[i], msg.payload)
 
     def test_broadcast(self):
-        executor = ThreadPoolExecutor(max_workers=len(self.workers))
-        all_task = [executor.submit(message_receive, (worker)) for worker in self.workers]
+        executor = ThreadPoolExecutor(max_workers=len(self.worker_proxy))
+        all_task = [executor.submit(message_receive, (worker)) for worker in self.worker_proxy]
 
         payload = ["broadcast_unit_test"]
-        self.master.ibroadcast(tag="unit_test",
-                               session_type=SessionType.NOTIFICATION,
-                               payload=payload)
+        self.master_proxy.ibroadcast(tag="unit_test",
+                                     session_type=SessionType.NOTIFICATION,
+                                     payload=payload)
 
         for task in as_completed(all_task):
             res = task.result()
             self.assertEqual(res, payload)
 
     def test_reply(self):
-        for worker in self.workers:
+        for worker in self.worker_proxy:
             send_msg = SessionMessage(tag="unit_test",
-                                      source=self.master.component_name,
+                                      source=self.master_proxy.component_name,
                                       destination=worker.component_name,
                                       payload="hello ")
-            session_id_list = self.master.isend(send_msg)
+            session_id_list = self.master_proxy.isend(send_msg)
 
             for receive_message in worker.receive(is_continuous=False):
                 worker.reply(received_message=receive_message, tag="unit_test", payload="world!")
 
-            replied_msg_list = self.master.receive_by_id(session_id_list)
+            replied_msg_list = self.master_proxy.receive_by_id(session_id_list)
             self.assertEqual(send_msg.payload + replied_msg_list[0].payload, "hello world!")
 
 

--- a/tests/communication/test_proxy.py
+++ b/tests/communication/test_proxy.py
@@ -2,30 +2,12 @@
 # Licensed under the MIT license.
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import redis
 import subprocess
-import time
 import unittest
 import os
 
 from maro.communication import Proxy, SessionMessage, SessionType
-from utils import get_random_port
-
-
-def proxy_generator(component_type, redis_port):
-    if component_type == "master":
-        proxy = Proxy(group_name="proxy_unit_test",
-                      component_type="master",
-                      expected_peers={"worker": 5},
-                      redis_address=("localhost", redis_port),
-                      log_enable=False)
-    elif component_type == "worker":
-        proxy = Proxy(group_name="proxy_unit_test",
-                      component_type="worker",
-                      expected_peers={"master": 1},
-                      redis_address=("localhost", redis_port),
-                      log_enable=False)
-    return proxy
+from utils import get_random_port, proxy_generator
 
 
 def message_receive(proxy):
@@ -40,22 +22,22 @@ class TestProxy(unittest.TestCase):
     def setUpClass(cls):
         print(f"The proxy unit test start!")
         # prepare Redis
-        random_port = get_random_port()
-        cls.redis_process = subprocess.Popen(["redis-server", "--port", str(random_port), "--daemonize yes"])
+        redis_port = get_random_port()
+        cls.redis_process = subprocess.Popen(["redis-server", "--port", str(redis_port), "--daemonize yes"])
         cls.redis_process.wait()
 
         # prepare proxies
-        cls.worker_proxy = []
+        cls.worker_proxies = []
         proxy_type_list = ["master"] + ["worker"] * 5
         with ThreadPoolExecutor(max_workers=6) as executor:
-            all_task = [executor.submit(proxy_generator, proxy_type, random_port) for proxy_type in proxy_type_list]
+            all_tasks = [executor.submit(proxy_generator, proxy_type, redis_port) for proxy_type in proxy_type_list]
 
-            for task in as_completed(all_task):
+            for task in as_completed(all_tasks):
                 result = task.result()
                 if "master" in result.component_name:
                     cls.master_proxy = result
                 else:
-                    cls.worker_proxy.append(result)
+                    cls.worker_proxies.append(result)
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -64,52 +46,52 @@ class TestProxy(unittest.TestCase):
             cls.redis_process.kill()
 
     def test_send(self):
-        for worker in self.worker_proxy:
+        for worker_proxy in self.worker_proxies:
             send_msg = SessionMessage(tag="unit_test",
                                       source=self.master_proxy.component_name,
-                                      destination=worker.component_name,
+                                      destination=worker_proxy.component_name,
                                       payload="hello_world!")
             self.master_proxy.isend(send_msg)
 
-            for receive_message in worker.receive(is_continuous=False):
+            for receive_message in worker_proxy.receive(is_continuous=False):
                 self.assertEqual(send_msg.payload, receive_message.payload)
 
     def test_scatter(self):
         scatter_payload = ["worker_1", "worker_2", "worker_3", "worker_4", "worker_5"]
-        destination_payload_list = [(worker.component_name, scatter_payload[i])
-                                    for i, worker in enumerate(self.worker_proxy)]
+        destination_payload_list = [(worker_proxy.component_name, scatter_payload[i])
+                                    for i, worker_proxy in enumerate(self.worker_proxies)]
 
         self.master_proxy.iscatter(tag="unit_test",
                                    session_type=SessionType.NOTIFICATION,
                                    destination_payload_list=destination_payload_list)
 
-        for i, worker in enumerate(self.worker_proxy):
-            for msg in worker.receive(is_continuous=False):
+        for i, worker_proxy in enumerate(self.worker_proxies):
+            for msg in worker_proxy.receive(is_continuous=False):
                 self.assertEqual(scatter_payload[i], msg.payload)
 
     def test_broadcast(self):
-        executor = ThreadPoolExecutor(max_workers=len(self.worker_proxy))
-        all_task = [executor.submit(message_receive, (worker)) for worker in self.worker_proxy]
+        with ThreadPoolExecutor(max_workers=len(self.worker_proxies)) as executor:
+            all_tasks = [executor.submit(message_receive, worker_proxy) for worker_proxy in self.worker_proxies]
 
-        payload = ["broadcast_unit_test"]
-        self.master_proxy.ibroadcast(tag="unit_test",
-                                     session_type=SessionType.NOTIFICATION,
-                                     payload=payload)
+            payload = ["broadcast_unit_test"]
+            self.master_proxy.ibroadcast(tag="unit_test",
+                                         session_type=SessionType.NOTIFICATION,
+                                         payload=payload)
 
-        for task in as_completed(all_task):
-            res = task.result()
-            self.assertEqual(res, payload)
+            for task in as_completed(all_tasks):
+                result = task.result()
+                self.assertEqual(result, payload)
 
     def test_reply(self):
-        for worker in self.worker_proxy:
+        for worker_proxy in self.worker_proxies:
             send_msg = SessionMessage(tag="unit_test",
                                       source=self.master_proxy.component_name,
-                                      destination=worker.component_name,
+                                      destination=worker_proxy.component_name,
                                       payload="hello ")
             session_id_list = self.master_proxy.isend(send_msg)
 
-            for receive_message in worker.receive(is_continuous=False):
-                worker.reply(received_message=receive_message, tag="unit_test", payload="world!")
+            for receive_message in worker_proxy.receive(is_continuous=False):
+                worker_proxy.reply(received_message=receive_message, tag="unit_test", payload="world!")
 
             replied_msg_list = self.master_proxy.receive_by_id(session_id_list)
             self.assertEqual(send_msg.payload + replied_msg_list[0].payload, "hello world!")

--- a/tests/communication/test_proxy.py
+++ b/tests/communication/test_proxy.py
@@ -21,12 +21,12 @@ class TestProxy(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         print(f"The proxy unit test start!")
-        # prepare Redis
+        # Initial Redis
         redis_port = get_random_port()
         cls.redis_process = subprocess.Popen(["redis-server", "--port", str(redis_port), "--daemonize yes"])
         cls.redis_process.wait()
 
-        # prepare proxies
+        # Initial proxies
         cls.worker_proxies = []
         proxy_type_list = ["master"] + ["worker"] * 5
         with ThreadPoolExecutor(max_workers=6) as executor:

--- a/tests/communication/test_proxy.py
+++ b/tests/communication/test_proxy.py
@@ -47,15 +47,15 @@ class TestProxy(unittest.TestCase):
         # prepare proxies
         cls.workers = []
         proxy_type_list = ["master"] + ["worker"]*5
-        executor = ThreadPoolExecutor(max_workers=6)
-        all_task = [executor.submit(proxy_generator, (proxy_type)) for proxy_type in proxy_type_list]
+        with ThreadPoolExecutor(max_workers=6) as executor:
+            all_task = [executor.submit(proxy_generator, (proxy_type)) for proxy_type in proxy_type_list]
 
-        for task in as_completed(all_task):
-            r = task.result()
-            if "master" in r.component_name:
-                cls.master = r
-            else:
-                cls.workers.append(r)
+            for task in as_completed(all_task):
+                r = task.result()
+                if "master" in r.component_name:
+                    cls.master = r
+                else:
+                    cls.workers.append(r)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/tests/communication/test_registry_table.py
+++ b/tests/communication/test_registry_table.py
@@ -63,12 +63,12 @@ class TestRegisterTable(unittest.TestCase):
         # Accept a message from worker_a with tag_a.
         unit_event_1 = "worker_a:tag_a:1"
         self.register_table.register_event_handler(unit_event_1, handle_function)
-        for msg in self.message_dict["worker_a"]["tag_a"]:
+        for msg in TestRegisterTable.message_dict["worker_a"]["tag_a"]:
             # The message from worker_a with tag_a, it will trigger handler function each time.
             self.register_table.push(msg)
             self.assertIsNotNone(self.register_table.get())
 
-        for msg in self.message_dict["worker_b"]["tag_b"]:
+        for msg in TestRegisterTable.message_dict["worker_b"]["tag_b"]:
             # The message from worker_b with tag_b, the register table won't be trigger anytime.
             self.register_table.push(msg)
             self.assertEqual(self.register_table.get(), [])
@@ -77,12 +77,12 @@ class TestRegisterTable(unittest.TestCase):
         # Accept a message from worker_a with any tags.
         unit_event_2 = "worker_a:*:1"
         self.register_table.register_event_handler(unit_event_2, handle_function)
-        for msg in self.message_dict["worker_a"]["tag_a"] + self.message_dict["worker_a"]["tag_b"]:
+        for msg in TestRegisterTable.message_dict["worker_a"]["tag_a"] + TestRegisterTable.message_dict["worker_a"]["tag_b"]:
             # The message from worker_a with any tags, it will trigger handler function each time.
             self.register_table.push(msg)
             self.assertIsNotNone(self.register_table.get())
 
-        for msg in self.message_dict["worker_b"]["tag_a"]:
+        for msg in TestRegisterTable.message_dict["worker_b"]["tag_a"]:
             # The message from worker_b with tag_a, it won't trigger handler function.
             self.register_table.push(msg)
             self.assertEqual(self.register_table.get(), [])
@@ -91,7 +91,8 @@ class TestRegisterTable(unittest.TestCase):
         # Accept messages from any source with tag_a until the number of message reach 60% of source number.
         unit_event_2 = "*:tag_a:50%"
         self.register_table.register_event_handler(unit_event_2, handle_function)
-        for idx, msg in enumerate(self.message_dict["worker_a"]["tag_a"] + self.message_dict["worker_b"]["tag_a"]):
+        for idx, msg in enumerate(TestRegisterTable.message_dict["worker_a"]["tag_a"] + 
+                                  TestRegisterTable.message_dict["worker_b"]["tag_a"]):
             # The message with tag_a, it will trigger handler function until receiving 5 times.
             self.register_table.push(msg)
             if (idx + 1) % 5 == 0:
@@ -103,7 +104,8 @@ class TestRegisterTable(unittest.TestCase):
         # Accept the combination of two messages: one from worker_a with tag_a, and one from worker_b with tag_a.
         and_conditional_event = ("worker_a:tag_a:1", "worker_b:tag_a:1", "AND")
         self.register_table.register_event_handler(and_conditional_event, handle_function)
-        for idx, msg in enumerate(self.message_dict["worker_a"]["tag_a"] + self.message_dict["worker_b"]["tag_a"]):
+        for idx, msg in enumerate(TestRegisterTable.message_dict["worker_a"]["tag_a"] + 
+                                  TestRegisterTable.message_dict["worker_b"]["tag_a"]):
             # The messages with tag_a from worker_a and worker_b, it will trigger handler function until the
             # combination be satisfied.
             self.register_table.push(msg)
@@ -115,7 +117,8 @@ class TestRegisterTable(unittest.TestCase):
         # Accept the message from worker_a with tag_a, or from worker_b with tag_a.
         or_conditional_event = ("worker_a:tag_a:1", "worker_b:tag_a:1", "OR")
         self.register_table.register_event_handler(or_conditional_event, handle_function)
-        for idx, msg in enumerate(self.message_dict["worker_a"]["tag_a"] + self.message_dict["worker_b"]["tag_a"]):
+        for idx, msg in enumerate(TestRegisterTable.message_dict["worker_a"]["tag_a"] + 
+                                  TestRegisterTable.message_dict["worker_b"]["tag_a"]):
             # The messages with tag_a from worker_a and worker_b, it will trigger handler function each time.
             self.register_table.push(msg)
             self.assertIsNotNone(self.register_table.get())
@@ -126,10 +129,11 @@ class TestRegisterTable(unittest.TestCase):
         recurrent_conditional_event = (("worker_a:tag_a:1", "worker_b:tag_a:1", "AND"), "worker_a:tag_b:1", "AND")
         self.register_table.register_event_handler(recurrent_conditional_event, handle_function)
 
-        for msg in self.message_dict["worker_a"]["tag_a"] + self.message_dict["worker_b"]["tag_a"]:
+        for msg in TestRegisterTable.message_dict["worker_a"]["tag_a"] + \
+                   TestRegisterTable.message_dict["worker_b"]["tag_a"]:
             self.register_table.push(msg)
 
-        for msg in self.message_dict["worker_a"]["tag_b"]:
+        for msg in TestRegisterTable.message_dict["worker_a"]["tag_b"]:
             self.register_table.push(msg)
             self.assertIsNotNone(self.register_table.get())
 
@@ -140,7 +144,7 @@ class TestRegisterTable(unittest.TestCase):
         unit_event_2 = "worker_a:*:1"
         self.register_table.register_event_handler(unit_event_1, handle_function)
         self.register_table.register_event_handler(unit_event_2, handle_function)
-        for msg in self.message_dict["worker_a"]["tag_a"]:
+        for msg in TestRegisterTable.message_dict["worker_a"]["tag_a"]:
             # For each message from worker_a with tag_a, it will trigger two handler functions, and both of them will
             # have the same message.
             self.register_table.push(msg)

--- a/tests/communication/test_zmq_driver.py
+++ b/tests/communication/test_zmq_driver.py
@@ -39,29 +39,29 @@ class TestDriver(unittest.TestCase):
         print(f"The ZMQ driver unit test finished!")
 
     def test_send(self):
-        for peer in self.peer_list:
+        for peer in TestDriver.peer_list:
             message = SessionMessage(tag="unit_test",
                                      source="sender",
                                      destination=peer,
                                      payload="hello_world")
-            self.sender.send(message)
+            TestDriver.sender.send(message)
 
-            for received_message in self.receivers[peer].receive(is_continuous=False):
+            for received_message in TestDriver.receivers[peer].receive(is_continuous=False):
                 self.assertEqual(received_message.payload, message.payload)
 
     def test_broadcast(self):
-        executor = ThreadPoolExecutor(max_workers=len(self.peer_list))
-        all_task = [executor.submit(message_receive, (self.receivers[peer])) for peer in self.peer_list]
+        with ThreadPoolExecutor(max_workers=len(TestDriver.peer_list)) as executor:
+            all_task = [executor.submit(message_receive, (TestDriver.receivers[peer])) for peer in TestDriver.peer_list]
 
-        message = SessionMessage(tag="unit_test",
-                                 source="sender",
-                                 destination="*",
-                                 payload="hello_world")
-        self.sender.broadcast(message)
+            message = SessionMessage(tag="unit_test",
+                                     source="sender",
+                                     destination="*",
+                                     payload="hello_world")
+            TestDriver.sender.broadcast(message)
 
-        for task in as_completed(all_task):
-            res = task.result()
-            self.assertEqual(res, message.payload)
+            for task in all_task:
+                res = task.result()
+                self.assertEqual(res, message.payload)
 
 
 if __name__ == "__main__":

--- a/tests/communication/test_zmq_driver.py
+++ b/tests/communication/test_zmq_driver.py
@@ -19,11 +19,11 @@ class TestDriver(unittest.TestCase):
     def setUpClass(cls) -> None:
         print(f"The ZMQ driver unit test start!")
         cls.peer_list = ["receiver_1", "receiver_2", "receiver_3"]
-        # send driver
+        # Initial send driver.
         cls.sender = ZmqDriver()
         sender_address = cls.sender.address
 
-        # receive drivers
+        # Initial receive drivers.
         cls.receivers = {}
         receiver_addresses = {}
         for peer in cls.peer_list:

--- a/tests/communication/utils.py
+++ b/tests/communication/utils.py
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import socket
+
+
+def get_random_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as temp_socket:
+        temp_socket.bind(("", 0))
+        random_port = temp_socket.getsockname()[1]
+    
+    return random_port

--- a/tests/communication/utils.py
+++ b/tests/communication/utils.py
@@ -3,6 +3,8 @@
 
 import socket
 
+from maro.communication import Proxy
+
 
 def get_random_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as temp_socket:
@@ -10,3 +12,20 @@ def get_random_port():
         random_port = temp_socket.getsockname()[1]
     
     return random_port
+
+
+def proxy_generator(component_type, redis_port):
+    proxy_parameters = {"group_name": "communication_unit_test",
+                        "redis_address": ("localhost", redis_port),
+                        "log_enable": False}
+                        
+    component_type_expected_peers_map = {"receiver": {"sender": 1},
+                                         "sender": {"receiver": 1},
+                                         "master": {"worker": 5},
+                                         "worker": {"master": 1}}
+
+    proxy = Proxy(component_type=component_type,
+                  expected_peers=component_type_expected_peers_map[component_type],
+                  **proxy_parameters)
+
+    return proxy


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->

Switching the key and values of the ``handler dict`` which is used in the ``dist`` decorator.
Add unit tests for the dist decorator.
Fixed the multithreading deadlock in the maro unit test suite. 

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->

## Type of Change

- [x] Non-breaking bug fix
- [ ] Breaking bug fix
- [x] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [x] Distributed toolkit

## Has Been Tested

- OS:
  - [x] Windows
  - [x] Mac OS
  - [x] Linux
- Python version:
  - [x] 3.6
  - [x] 3.7
- Key information snapshot(s):
  
## Needs Follow Up Actions

- [ ] New release package
- [x] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
