### PR TITLE
Event payload details for env.summary

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Please also add other related information/contexts/dependencies here.
   - [ ] 3.6
   - [ ] 3.7
 - Key information snapshot(s):
-  
+
 ## Needs Follow Up Actions
 
 - [ ] New release package

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
 Multi-Agent Resource Optimization (MARO) platform is an instance of Reinforcement
 learning as a Service (RaaS) for real-world resource optimization. It can be
 applied to many important industrial domains, such as [container inventory
-management](https://maro.readthedocs.io/en/v0.1/scenarios/container_inventory_management.html) 
-in logistics, [bike repositioning](https://maro.readthedocs.io/en/v0.1/scenarios/citi_bike.html) 
+management](https://maro.readthedocs.io/en/v0.1/scenarios/container_inventory_management.html)
+in logistics, [bike repositioning](https://maro.readthedocs.io/en/v0.1/scenarios/citi_bike.html)
 in transportation, virtual machine provisioning in data centers, and asset management in finance. Besides
 [Reinforcement Learning](https://www.andrew.cmu.edu/course/10-703/textbook/BartoSutton.pdf) (RL),
 it also supports other planning/decision mechanisms, such as
@@ -79,7 +79,7 @@ of user-defined functions for message auto-handling, cluster provision, and job 
 - Prerequisites
   - C++ Compiler
     - Linux or Mac OS X: `gcc`
-    - Windows: [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15) 
+    - Windows: [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15)
 
 - Enable Virtual Environment
   - Mac OS / Linux

--- a/examples/cim/dqn/README.md
+++ b/examples/cim/dqn/README.md
@@ -8,13 +8,13 @@ through config.yml. Each RL formulation has a dedicated folder, e.g., dqn, and
 all algorithm-specific parameters can be configured through
 the config.py file in that folder.
 
-# Single-host Single-process Mode
+## Single-host Single-process Mode
 
 To run the CIM example using the DQN algorithm under single-host mode, go to
 examples/cim/dqn and run single_process_launcher.py. You may play around with
 the configuration if you want to try out different settings.
 
-# Distributed Mode
+## Distributed Mode
 
 The examples/cim/dqn/components folder contains dist_learner.py and dist_actor.py
 for distributed training. For debugging purposes, we provide a script that

--- a/examples/cim/dqn/components/state_shaper.py
+++ b/examples/cim/dqn/components/state_shaper.py
@@ -23,7 +23,7 @@ class CIMStateShaper(StateShaper):
         vessel_features = snapshot_list["vessels"][tick: vessel_idx: self._vessel_attributes]
         state = np.concatenate((port_features, vessel_features))
         return str(port_idx), state
-    
+
     @property
     def dim(self):
         return self._dim

--- a/maro/data_lib/__init__.py
+++ b/maro/data_lib/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from .binary_reader import BinaryReader
+from .binary_reader import BinaryReader, ItemTickPicker
 from .binary_converter import BinaryConverter
 
 
-__all__ = ["BinaryReader", "BinaryConverter"]
+__all__ = ["BinaryReader", "BinaryConverter", "ItemTickPicker"]

--- a/maro/data_lib/cim/entities.py
+++ b/maro/data_lib/cim/entities.py
@@ -88,6 +88,7 @@ class Order:
     """
     Used to hold order information, this is for order generation.
     """
+    key_list = ["tick", "src_port_idx", "dest_port_idx", "quantity"]
 
     def __init__(self, tick: int, src_port_idx: int, dest_port_idx: int, quantity: int):
         """

--- a/maro/data_lib/cim/entities.py
+++ b/maro/data_lib/cim/entities.py
@@ -106,5 +106,7 @@ class Order:
         self.dest_port_idx = dest_port_idx
 
     def __repr__(self):
-        return f"Order {{tick:{self.tick}, source port: {self.src_port_idx}, dest port: \
-         {self.dest_port_idx} quantity: {self.quantity}}}"
+        return (
+            f"Order {{tick:{self.tick}, source port: {self.src_port_idx}, "
+            f"dest port: {self.dest_port_idx} quantity: {self.quantity}}}"
+        )

--- a/maro/data_lib/cim/entities.py
+++ b/maro/data_lib/cim/entities.py
@@ -88,7 +88,7 @@ class Order:
     """
     Used to hold order information, this is for order generation.
     """
-    key_list = ["tick", "src_port_idx", "dest_port_idx", "quantity"]
+    summary_key = ["tick", "src_port_idx", "dest_port_idx", "quantity"]
 
     def __init__(self, tick: int, src_port_idx: int, dest_port_idx: int, quantity: int):
         """

--- a/maro/simulator/core.py
+++ b/maro/simulator/core.py
@@ -104,7 +104,8 @@ class Env(AbsEnv):
         """dict: Summary about current simulator, including node details and mappings."""
         return {
             "node_mapping": self._business_engine.get_node_mapping(),
-            "node_detail": self.current_frame.get_node_info()
+            "node_detail": self.current_frame.get_node_info(),
+            "event_payload": self._business_engine.get_event_payload_detail(),
         }
 
     @property

--- a/maro/simulator/scenarios/abs_business_engine.py
+++ b/maro/simulator/scenarios/abs_business_engine.py
@@ -164,6 +164,17 @@ class AbsBusinessEngine(ABC):
         """
         return {}
 
+    def get_event_payload_detail(self) -> dict:
+        """Get payload keys for all kinds of event.
+
+        For the performance of the simulator, some event payload has no corresponding Python object.
+        This mapping is provided for your convenience in such case.
+
+        Returns:
+            dict: Key is the event type in string format, value is a list of available keys.
+        """
+        return {}
+
     def get_metrics(self) -> dict:
         """Get statistics information, may different for scenarios.
 

--- a/maro/simulator/scenarios/cim/business_engine.py
+++ b/maro/simulator/scenarios/cim/business_engine.py
@@ -12,7 +12,7 @@ from maro.event_buffer import DECISION_EVENT, Event, EventBuffer
 from maro.simulator.scenarios import AbsBusinessEngine
 from maro.simulator.scenarios.helpers import MatrixAttributeAccessor, DocableDict
 
-from .common import ActionScope, DecisionEvent, CimEventType, VesselDischargePayload, VesselStatePayload
+from .common import Action, ActionScope, DecisionEvent, CimEventType, VesselDischargePayload, VesselStatePayload
 from .frame_builder import gen_cim_frame
 from maro.data_lib.cim import Stop, Order, CimDataContainerWrapper
 
@@ -260,6 +260,23 @@ class CimBusinessEngine(AbsBusinessEngine):
         return {
             "ports": self._data_cntr.port_mapping,
             "vessels": self._data_cntr.vessel_mapping
+        }
+
+    def get_event_payload_detail(self) -> dict:
+        """dict: Event payload details of current scenario."""
+        return {
+            CimEventType.ORDER.name: Order.key_list,
+            CimEventType.RELEASE_EMPTY.name: [],    # Never used.
+            CimEventType.RETURN_FULL.name: [],      # Tuple only: (order.src_port_idx, order.dest_port_idx, execute_qty)
+            CimEventType.VESSEL_ARRIVAL.name: VesselStatePayload.key_list,
+            CimEventType.LOAD_FULL.name: VesselStatePayload.key_list,
+            CimEventType.DISCHARGE_FULL.name: VesselDischargePayload.key_list,
+            CimEventType.PENDING_DECISION.name: DecisionEvent.key_list,
+            CimEventType.LOAD_EMPTY.name: Action.key_list,       # From DECISION_EVENT
+            CimEventType.DISCHARGE_EMPTY.name: Action.key_list,  # From DECISION_EVENT
+            CimEventType.VESSEL_DEPARTURE.name: VesselStatePayload.key_list,
+            CimEventType.RELEASE_FULL.name: [],     # Never used.
+            CimEventType.RETURN_EMPTY.name: []      # Tuple only: (discharge_qty, port.idx)
         }
 
     def get_agent_idx_list(self) -> list:

--- a/maro/simulator/scenarios/cim/business_engine.py
+++ b/maro/simulator/scenarios/cim/business_engine.py
@@ -12,7 +12,10 @@ from maro.event_buffer import DECISION_EVENT, Event, EventBuffer
 from maro.simulator.scenarios import AbsBusinessEngine
 from maro.simulator.scenarios.helpers import MatrixAttributeAccessor, DocableDict
 
-from .common import Action, ActionScope, DecisionEvent, CimEventType, VesselDischargePayload, VesselStatePayload
+from .common import (
+    Action, ActionScope, DecisionEvent, CimEventType,
+    VesselDischargePayload, VesselStatePayload, LadenReturnPayload, EmptyReturnPayload
+)
 from .frame_builder import gen_cim_frame
 from maro.data_lib.cim import Stop, Order, CimDataContainerWrapper
 
@@ -265,18 +268,16 @@ class CimBusinessEngine(AbsBusinessEngine):
     def get_event_payload_detail(self) -> dict:
         """dict: Event payload details of current scenario."""
         return {
-            CimEventType.ORDER.name: Order.key_list,
-            CimEventType.RELEASE_EMPTY.name: [],    # Never used.
-            CimEventType.RETURN_FULL.name: [],      # Tuple only: (order.src_port_idx, order.dest_port_idx, execute_qty)
-            CimEventType.VESSEL_ARRIVAL.name: VesselStatePayload.key_list,
-            CimEventType.LOAD_FULL.name: VesselStatePayload.key_list,
-            CimEventType.DISCHARGE_FULL.name: VesselDischargePayload.key_list,
-            CimEventType.PENDING_DECISION.name: DecisionEvent.key_list,
-            CimEventType.LOAD_EMPTY.name: Action.key_list,       # From DECISION_EVENT
-            CimEventType.DISCHARGE_EMPTY.name: Action.key_list,  # From DECISION_EVENT
-            CimEventType.VESSEL_DEPARTURE.name: VesselStatePayload.key_list,
-            CimEventType.RELEASE_FULL.name: [],     # Never used.
-            CimEventType.RETURN_EMPTY.name: []      # Tuple only: (discharge_qty, port.idx)
+            CimEventType.ORDER.name: Order.summary_key,
+            CimEventType.RETURN_FULL.name: LadenReturnPayload.summary_key,
+            CimEventType.VESSEL_ARRIVAL.name: VesselStatePayload.summary_key,
+            CimEventType.LOAD_FULL.name: VesselStatePayload.summary_key,
+            CimEventType.DISCHARGE_FULL.name: VesselDischargePayload.summary_key,
+            CimEventType.PENDING_DECISION.name: DecisionEvent.summary_key,
+            CimEventType.LOAD_EMPTY.name: Action.summary_key,
+            CimEventType.DISCHARGE_EMPTY.name: Action.summary_key,
+            CimEventType.VESSEL_DEPARTURE.name: VesselStatePayload.summary_key,
+            CimEventType.RETURN_EMPTY.name: EmptyReturnPayload.summary_key
         }
 
     def get_agent_idx_list(self) -> list:
@@ -415,10 +416,12 @@ class CimBusinessEngine(AbsBusinessEngine):
 
         buffer_ticks = self._data_cntr.full_return_buffers[src_port.idx]
 
-        payload = (order.src_port_idx, order.dest_port_idx, execute_qty)
+        payload = LadenReturnPayload(
+            src_port_idx=order.src_port_idx, dest_port_idx=order.dest_port_idx, quantity=execute_qty
+        )
 
         laden_return_evt = self._event_buffer.gen_atom_event(
-            evt.tick + buffer_ticks, CimEventType.RETURN_FULL, payload
+            tick=evt.tick + buffer_ticks, event_type=CimEventType.RETURN_FULL, payload=payload
         )
 
         # If buffer_tick is 0, we should execute it as this tick.
@@ -434,19 +437,15 @@ class CimBusinessEngine(AbsBusinessEngine):
         1. First move the container from on_shipper to full (update state: on_shipper -> full).
         2. Then append the container to the port pending list.
         """
-        # The payload is a tuple (src_port_idx, dest_port_idx, quantity).
-        full_rtn_payload = evt.payload
-        src_port_idx = full_rtn_payload[0]
-        dest_port_idx = full_rtn_payload[1]
-        qty = full_rtn_payload[2]
+        payload: LadenReturnPayload = evt.payload
 
-        src_port = self._ports[src_port_idx]
-        src_port.on_shipper -= qty
-        src_port.full += qty
+        src_port = self._ports[payload.src_port_idx]
+        src_port.on_shipper -= payload.quantity
+        src_port.full += payload.quantity
 
-        pending_full_number = self._get_pending_full(src_port_idx, dest_port_idx)
+        pending_full_number = self._get_pending_full(payload.src_port_idx, payload.dest_port_idx)
 
-        self._set_pending_full(src_port_idx, dest_port_idx, pending_full_number + qty)
+        self._set_pending_full(payload.src_port_idx, payload.dest_port_idx, pending_full_number + payload.quantity)
 
     def _on_full_load(self, evt: Event):
         """Handler for processing event that a vessel need to load full containers from current port.
@@ -559,9 +558,10 @@ class CimBusinessEngine(AbsBusinessEngine):
         self._full_on_vessels[vessel_idx, port_idx] -= discharge_qty
 
         buffer_ticks = self._data_cntr.empty_return_buffers[port.idx]
-        payload = (discharge_qty, port.idx)
+        payload = EmptyReturnPayload(port_idx=port.idx, quantity=discharge_qty)
         mt_return_evt = self._event_buffer.gen_atom_event(
-            evt.tick + buffer_ticks, CimEventType.RETURN_EMPTY, payload)
+            tick=evt.tick + buffer_ticks, event_type=CimEventType.RETURN_EMPTY, payload=payload
+        )
 
         if buffer_ticks == 0:
             evt.immediate_event_list.append(mt_return_evt)
@@ -574,11 +574,11 @@ class CimBusinessEngine(AbsBusinessEngine):
         Args:
             evt (Event Object): Empty-return event object.
         """
-        qty, port_idx = evt.payload
-        port = self._ports[port_idx]
+        payload: EmptyReturnPayload = evt.payload
+        port = self._ports[payload.port_idx]
 
-        port.on_consignee -= qty
-        port.empty += qty
+        port.on_consignee -= payload.quantity
+        port.empty += payload.quantity
 
     def _on_action_received(self, evt: Event):
         """Handler for processing actions from agent.

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -38,6 +38,8 @@ class VesselStatePayload:
         port_idx (int): Which port the vessel at.
         vessel_idx (int): Which vessel's state changed.
     """
+    key_list = ["port_idx", "vessel_idx"]
+
     def __init__(self, port_idx: int, vessel_idx: int):
 
         self.port_idx = port_idx
@@ -56,6 +58,8 @@ class VesselDischargePayload:
         port_idx (int): Which port will receive the discharged containers.
         quantity (int): How many containers will be discharged.
     """
+    key_list = ["vessel_idx", "port_idx", "from_port_idx", "quantity"]
+
     def __init__(self, vessel_idx: int, from_port_idx: int, port_idx: int, quantity: int):
         self.vessel_idx = vessel_idx
         self.from_port_idx = from_port_idx
@@ -74,6 +78,7 @@ class Action:
         port_idx (int): Which port will take action.
         quantity (int): How many containers can be moved from vessel to port (negative in reverse).
     """
+    key_list = ["port_idx", "vessel_idx", "quantity"]
 
     def __init__(self, vessel_idx: int, port_idx: int, quantity: int):
         self.vessel_idx = vessel_idx
@@ -119,6 +124,8 @@ class DecisionEvent:
         early_discharge_func (Function): Function to fetch early discharge number of specified vessel, we
             use function here to make it getting the value as late as possible.
     """
+    key_list = ["tick", "port_idx", "vessel_idx", "snapshot_list", "action_scope", "early_discharge"]
+
     def __init__(self, tick: int, port_idx: int, vessel_idx: int, snapshot_list: SnapshotList,
                  action_scope_func, early_discharge_func):
         self.tick = tick

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -126,8 +126,10 @@ class DecisionEvent:
     """
     key_list = ["tick", "port_idx", "vessel_idx", "snapshot_list", "action_scope", "early_discharge"]
 
-    def __init__(self, tick: int, port_idx: int, vessel_idx: int, snapshot_list: SnapshotList,
-                 action_scope_func, early_discharge_func):
+    def __init__(
+        self, tick: int, port_idx: int, vessel_idx: int, snapshot_list: SnapshotList,
+        action_scope_func, early_discharge_func
+    ):
         self.tick = tick
         self.port_idx = port_idx
         self.vessel_idx = vessel_idx

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -7,20 +7,18 @@ from maro.backends.frame import SnapshotList
 
 
 class VesselState(IntEnum):
-    """State of vessel.
-    """
+    """State of vessel."""
     PARKING = 0
     SAILING = 1
 
 
 class CimEventType(IntEnum):
-    """Event type for CIM problem.
-    """
-    RELEASE_EMPTY = 10
+    """Event type for CIM problem."""
+    # RELEASE_EMPTY = 10
     RETURN_FULL = 11
     LOAD_FULL = 12
     DISCHARGE_FULL = 13
-    RELEASE_FULL = 14
+    # RELEASE_FULL = 14
     RETURN_EMPTY = 15
     ORDER = 16
     VESSEL_ARRIVAL = 17
@@ -30,15 +28,14 @@ class CimEventType(IntEnum):
     DISCHARGE_EMPTY = 21
 
 
-# used for arrival and departure cascade event
 class VesselStatePayload:
-    """Payload object used to hold vessel state changes for event.
+    """Payload object used to hold vessel state changes for event, including VESSEL_ARRIVAL and VESSEL_DEPARTURE.
 
     Args:
         port_idx (int): Which port the vessel at.
         vessel_idx (int): Which vessel's state changed.
     """
-    key_list = ["port_idx", "vessel_idx"]
+    summary_key = ["port_idx", "vessel_idx"]
 
     def __init__(self, port_idx: int, vessel_idx: int):
 
@@ -58,7 +55,7 @@ class VesselDischargePayload:
         port_idx (int): Which port will receive the discharged containers.
         quantity (int): How many containers will be discharged.
     """
-    key_list = ["vessel_idx", "port_idx", "from_port_idx", "quantity"]
+    summary_key = ["vessel_idx", "port_idx", "from_port_idx", "quantity"]
 
     def __init__(self, vessel_idx: int, from_port_idx: int, port_idx: int, quantity: int):
         self.vessel_idx = vessel_idx
@@ -70,6 +67,45 @@ class VesselDischargePayload:
         return f"VesselDischargePayload {{ vessel: {self.vessel_idx}, port: {self.port_idx}, qty: {self.quantity} }}"
 
 
+class LadenReturnPayload:
+    """Payload object to hold information about the full return event.
+
+    Args:
+        src_port_idx (int): The source port of the laden, i.e, the source port of the corresponding order.
+        dest_port_idx (int): Which port the laden are to be sent, i.e, the destination port of the corresponding order.
+        quantity (int): How many ladens/containers are returned.
+    """
+    summary_key = ["src_port_idx", "dest_port_idx", "quantity"]
+
+    def __init__(self, src_port_idx: int, dest_port_idx: int, quantity: int):
+        self.src_port_idx = src_port_idx
+        self.dest_port_idx = dest_port_idx
+        self.quantity = quantity
+
+    def __repr__(self):
+        return (
+            f"LadenReturnPayload {{ source port: {self.src_port_idx}, destination port: {self.dest_port_idx}, "
+            f"quantity: {self.quantity}}}"
+        )
+
+
+class EmptyReturnPayload:
+    """Payload object to hold information about the empty return event.
+
+    Args:
+        port_idx (int): Which port the empty containers are returned to.
+        quantity (int): How many empty containers are returned.
+    """
+    summary_key = ["port_idx", "quantity"]
+
+    def __init__(self, port_idx: int, quantity: int):
+        self.port_idx = port_idx
+        self.quantity = quantity
+
+    def __repr__(self):
+        return f"EmptyReturnPayload {{ port idx: {self.port_idx}, quantity: {self.quantity}}}"
+
+
 class Action:
     """Action object that used to pass action from agent to business engine.
 
@@ -78,7 +114,7 @@ class Action:
         port_idx (int): Which port will take action.
         quantity (int): How many containers can be moved from vessel to port (negative in reverse).
     """
-    key_list = ["port_idx", "vessel_idx", "quantity"]
+    summary_key = ["port_idx", "vessel_idx", "quantity"]
 
     def __init__(self, vessel_idx: int, port_idx: int, quantity: int):
         self.vessel_idx = vessel_idx
@@ -124,7 +160,7 @@ class DecisionEvent:
         early_discharge_func (Function): Function to fetch early discharge number of specified vessel, we
             use function here to make it getting the value as late as possible.
     """
-    key_list = ["tick", "port_idx", "vessel_idx", "snapshot_list", "action_scope", "early_discharge"]
+    summary_key = ["tick", "port_idx", "vessel_idx", "snapshot_list", "action_scope", "early_discharge"]
 
     def __init__(
         self, tick: int, port_idx: int, vessel_idx: int, snapshot_list: SnapshotList,

--- a/maro/simulator/scenarios/citi_bike/business_engine.py
+++ b/maro/simulator/scenarios/citi_bike/business_engine.py
@@ -136,16 +136,11 @@ class CitibikeBusinessEngine(AbsBusinessEngine):
 
     def get_event_payload_detail(self) -> dict:
         """dict: Event payload details of current scenario."""
-        trip_keys = []
-        with open(f"/home/{getpass.getuser()}/.maro/data/citi_bike/meta/trips.yml", "r") as fp:
-            conf = safe_load(fp)
-            trip_keys = list(conf["entity"].keys())
-
         return {
-            CitiBikeEvents.RequireBike.name: trip_keys,
-            CitiBikeEvents.ReturnBike.name: BikeReturnPayload.key_list,
-            CitiBikeEvents.RebalanceBike.name: DecisionEvent.key_list,
-            CitiBikeEvents.DeliverBike.name: BikeTransferPayload.key_list
+            CitiBikeEvents.RequireBike.name: list(self._trip_reader.meta.columns.keys()),
+            CitiBikeEvents.ReturnBike.name: BikeReturnPayload.summary_key,
+            CitiBikeEvents.RebalanceBike.name: DecisionEvent.summary_key,
+            CitiBikeEvents.DeliverBike.name: BikeTransferPayload.summary_key
         }
 
     def reset(self):

--- a/maro/simulator/scenarios/citi_bike/business_engine.py
+++ b/maro/simulator/scenarios/citi_bike/business_engine.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import datetime
-import getpass
 import os
 from typing import List
 

--- a/maro/simulator/scenarios/citi_bike/common.py
+++ b/maro/simulator/scenarios/citi_bike/common.py
@@ -59,8 +59,9 @@ class DecisionEvent:
 
     key_list = ["station_idx", "tick", "frame_index", "type", "action_scope"]
 
-    def __init__(self, station_idx: int, tick: int,
-                 frame_index: int, action_scope_func: callable, decision_type: DecisionType):
+    def __init__(
+        self, station_idx: int, tick: int, frame_index: int, action_scope_func: callable, decision_type: DecisionType
+    ):
         self.station_idx = station_idx
         self.tick = tick
         self.frame_index = frame_index

--- a/maro/simulator/scenarios/citi_bike/common.py
+++ b/maro/simulator/scenarios/citi_bike/common.py
@@ -13,7 +13,7 @@ class BikeTransferPayload:
         number (int): How many bikes for current trip requirement.
     """
 
-    key_list = ["from_station_idx", "to_station_idx", "number"]
+    summary_key = ["from_station_idx", "to_station_idx", "number"]
 
     def __init__(self, from_station_idx: int, to_station_idx: int, number: int = 1):
         self.from_station_idx = from_station_idx
@@ -30,7 +30,7 @@ class BikeReturnPayload:
         number (int): How many bikes for current trip requirement.
     """
 
-    key_list = ["from_station_idx", "to_station_idx", "number"]
+    summary_key = ["from_station_idx", "to_station_idx", "number"]
 
     def __init__(self, from_station_idx: int, to_station_idx: int, number: int = 1):
         self.from_station_idx = from_station_idx
@@ -57,7 +57,7 @@ class DecisionEvent:
         decision_type (DecisionType): The type of this decision.
     """
 
-    key_list = ["station_idx", "tick", "frame_index", "type", "action_scope"]
+    summary_key = ["station_idx", "tick", "frame_index", "type", "action_scope"]
 
     def __init__(
         self, station_idx: int, tick: int, frame_index: int, action_scope_func: callable, decision_type: DecisionType

--- a/maro/simulator/scenarios/citi_bike/common.py
+++ b/maro/simulator/scenarios/citi_bike/common.py
@@ -13,6 +13,8 @@ class BikeTransferPayload:
         number (int): How many bikes for current trip requirement.
     """
 
+    key_list = ["from_station_idx", "to_station_idx", "number"]
+
     def __init__(self, from_station_idx: int, to_station_idx: int, number: int = 1):
         self.from_station_idx = from_station_idx
         self.to_station_idx = to_station_idx
@@ -27,6 +29,8 @@ class BikeReturnPayload:
         to_station_idx (int): Which station (index) this bike to.
         number (int): How many bikes for current trip requirement.
     """
+
+    key_list = ["from_station_idx", "to_station_idx", "number"]
 
     def __init__(self, from_station_idx: int, to_station_idx: int, number: int = 1):
         self.from_station_idx = from_station_idx
@@ -52,6 +56,8 @@ class DecisionEvent:
         action_scope_func (callable): Function to retrieve latest action scope states.
         decision_type (DecisionType): The type of this decision.
     """
+
+    key_list = ["station_idx", "tick", "frame_index", "type", "action_scope"]
 
     def __init__(self, station_idx: int, tick: int,
                  frame_index: int, action_scope_func: callable, decision_type: DecisionType):

--- a/maro/simulator/scenarios/citi_bike/meta/trips.yml
+++ b/maro/simulator/scenarios/citi_bike/meta/trips.yml
@@ -13,7 +13,7 @@ events:
     display_name: "rebalance_bike"
   DeliverBike:
     display_name: "deliver_bike"
-    
+
   "_default": "RequireBike" # default event type if not event type in column, such as citi_bike scenario, all the rows are trip_requirement, so we do not need to specified event column
 # entity used to specified which columns need to be extracted into binary, and its data type
 # current supported data types are: i, i2, i4, i8, f, d
@@ -24,14 +24,14 @@ entity:
     # Used to specified time zone in source file, converter will convert it into UTC,
     # Defaults to UTC if not specified:
     # name : https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-    tzone: "America/New_York" 
-  durations: 
+    tzone: "America/New_York"
+  durations:
     column: 'duration'
     dtype: 'i'
-  src_station: 
+  src_station:
     column: 'start_station_index'
     dtype: 'i'
-  dest_station: 
+  dest_station:
     column: 'end_station_index'
     dtype: 'i'
     slot: 1


### PR DESCRIPTION
# Description

- [x] Event payload details are added into the env.summary (**Discussion needed**).
- [x] Add two event payload class to replace the tuple payload in CIM.

## Linked issue(s)/Pull request(s)

- [118](https://github.com/microsoft/maro/issues/118): key_list in env.summary should be replaced after the object pool is done.

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [x] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [x] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):
  
## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
