### PR TITLE
Fix build wheel issue on linux

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -48,6 +48,7 @@ jobs:
         python-versions: 'cp36-cp36m cp37-cp37m'
         build-requirements: 'numpy'
         pip-wheel-args: '-w ./wheelhouse' # save wheel packages to wheelhouse folder
+        pre-build-command: 'export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH'
 
     - name: Move valid packages to dist folder for manylinux
       if: runner.os == 'Linux' && matrix.python-version == '3.6'


### PR DESCRIPTION
# Description

Fix issue that cannot find shared lib on linux when building wheels.

## Linked issue(s)/Pull request(s)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):
  
## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
