### PR TITLE
fix issue that sometimes there is conflict between distutils and setuptools 

### DIFF
--- a/.github/linters/tox.ini
+++ b/.github/linters/tox.ini
@@ -18,7 +18,8 @@ exclude =
     .vscode,
     .github,
     scripts,
-    tests
+    tests,
+    setup.py
 
 max-line-length = 120
 
@@ -35,4 +36,4 @@ use_parentheses = True
 multi_line_output = 6
 known_first_party = maro
 filter_files = True
-skip_glob = maro/__init__.py, tests/*, examples/*
+skip_glob = maro/__init__.py, tests/*, examples/*, setup.py

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ import os
 # NOTE: DO NOT change the import order, as there is conflict between cython and setuptools,
 # it will cause following error:
 # error: each element of 'ext_modules' option must be an Extension instance or 2-tuple
-from setuptools import setup, find_packages, Extension
+from setuptools import find_packages
+from distutils.core import setup
+from distutils.extension import Extension
 
 from maro import __version__
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@
 import io
 import os
 
-from setuptools import Extension, find_packages, setup
+# NOTE: DO NOT change the import order, as there is conflict between cython and setuptools,
+# it will cause following error:
+# error: each element of 'ext_modules' option must be an Extension instance or 2-tuple
+from setuptools import setup, find_packages, Extension
 
 from maro import __version__
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import io
 import os
 
-# NOTE: DO NOT change the import order, as there is conflict between cython and setuptools,
+# NOTE: DO NOT change the import order, as sometimes there is a conflict between setuptools and distutils,
 # it will cause following error:
 # error: each element of 'ext_modules' option must be an Extension instance or 2-tuple
 from setuptools import find_packages


### PR DESCRIPTION
# Description

Distutils and setuptools provide same class name for Extension, so we should carefully sort the import order to avoid this issue.

NOTE: 
  I cannot repro it on my mac with several version of setuptools, need the help of issue owner to double confirm with it. But it does exist, details see:

https://github.com/pypa/setuptools/issues/309

Changes:
  Seems like our old import order should work for this issue, but still try to apply fix from another project to make sure it would work. https://github.com/ucgmsim/IM_calculation/pull/65

Update:
 This fix use distutils.extension.Extension to override Extension from setuptools, should the type checking in build_ext method will not failed any more.

## Linked issue(s)/Pull request(s)

#207 

## Type of Change

- [ ] Non-breaking bug fix
- [x] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):
  
## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
