### PR TITLE
Bug fix: if decision event is not a dynamic object, then it will cause error

### DIFF
--- a/maro/simulator/core.py
+++ b/maro/simulator/core.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import warnings
-
 from collections import Iterable
 from importlib import import_module
 from inspect import getmembers, isclass
@@ -10,7 +9,8 @@ from typing import List
 
 from maro.backends.frame import FrameBase, SnapshotList
 from maro.event_buffer import EventBuffer, EventState
-from maro.utils.exception.simulator_exception import BusinessEngineNotFoundError
+from maro.utils.exception.simulator_exception import \
+  BusinessEngineNotFoundError
 
 from .abs_core import AbsEnv, DecisionMode
 from .scenarios.abs_business_engine import AbsBusinessEngine
@@ -293,7 +293,7 @@ class Env(AbsEnv):
 
                     if is_support_seq_action:
                         for i in range(1, pending_event_length):
-                            if pending_events[i].id == actions[0].source_event_id:
+                            if pending_events[i].id == action_related_event_id:
                                 pending_events[i].state = EventState.FINISHED
                                 break
                     else:

--- a/maro/simulator/core.py
+++ b/maro/simulator/core.py
@@ -9,8 +9,7 @@ from typing import List
 
 from maro.backends.frame import FrameBase, SnapshotList
 from maro.event_buffer import EventBuffer, EventState
-from maro.utils.exception.simulator_exception import \
-  BusinessEngineNotFoundError
+from maro.utils.exception.simulator_exception import BusinessEngineNotFoundError
 
 from .abs_core import AbsEnv, DecisionMode
 from .scenarios.abs_business_engine import AbsBusinessEngine


### PR DESCRIPTION

# Description

The old implementation that support joint decision mode with sequential action, will cause exception when inject source event id, there we only try to inject under joint mode.

## Linked issue(s)/Pull request(s)


## Type of Change

- [x] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):
  
## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
