### PR TITLE
Master.store bug fix

### DIFF
--- a/docs/source/key_components/rl_toolkit.rst
+++ b/docs/source/key_components/rl_toolkit.rst
@@ -22,10 +22,10 @@ Learner and Actor
   .. code-block:: python
 
     # Train function of learner.
-    def learn(self, total_episodes):
+    def learn(self):
         for exploration_params in self._scheduler:
             performance, exp_by_agent = self._actor.roll_out(
-                model_dict=None if self._is_shared_agent_instance() else self._agent_manager.dump_models(),
+                self._agent_manager.dump_models(),
                 exploration_params=exploration_params
             )
             self._scheduler.record_performance(performance)

--- a/maro/rl/algorithms/dqn.py
+++ b/maro/rl/algorithms/dqn.py
@@ -8,7 +8,7 @@ import torch
 
 from maro.rl.models.learning_model import LearningModel
 
-from .algorithms.abs_algorithm import AbsAlgorithm
+from .abs_algorithm import AbsAlgorithm
 
 
 class DQNConfig:

--- a/maro/rl/algorithms/dqn.py
+++ b/maro/rl/algorithms/dqn.py
@@ -6,8 +6,9 @@ from typing import Union
 import numpy as np
 import torch
 
-from maro.rl.algorithms.abs_algorithm import AbsAlgorithm
 from maro.rl.models.learning_model import LearningModel
+
+from .algorithms.abs_algorithm import AbsAlgorithm
 
 
 class DQNConfig:

--- a/maro/rl/storage/column_based_store.py
+++ b/maro/rl/storage/column_based_store.py
@@ -190,8 +190,10 @@ class ColumnBasedStore(AbsStore):
             Sampled indexes and the corresponding objects,
             e.g., [1, 2, 3], ['a', 'b', 'c'].
         """
-        weights = np.asarray(weights)
-        indexes = np.random.choice(self._size, size=size, replace=replace, p=weights / np.sum(weights))
+        if weights is not None:
+            weights = np.asarray(weights)
+            weights /= np.sum(weights)
+        indexes = np.random.choice(self._size, size=size, replace=replace, p=weights)
         return indexes, self.get(indexes)
 
     def sample_by_key(self, key, size: int, replace: bool = True):


### PR DESCRIPTION
# Description

An error would be raised in ColumnBasedStore's sample() method if weights are None (i.e., uniform sampling) because the logic did not properly handle this case. A few other minor issues with documentation were also fixed.  

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [x] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [x] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [x] Linux
- Python version:
  - [ ] 3.6
  - [x] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
