### PR TITLE
disable jscpd linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_PYTHON_PYLINT: false # disable pylint, as we have not configure it
           VALIDATE_PYTHON_BLACK: false # same as above
+          VALIDATE_JSCPD: false # Can not exclude specific file: https://github.com/kucherenko/jscpd/issues/215
           PYTHON_FLAKE8_CONFIG_FILE: tox.ini
           PYTHON_ISORT_CONFIG_FILE: tox.ini
           EDITORCONFIG_FILE_NAME: ../../.editorconfig


### PR DESCRIPTION
# Description

Due to https://github.com/kucherenko/jscpd/issues/215, the jscpd linter can't exclude specific file.

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
