### PR TITLE
fix bug: subprocess failed to execute 'sh run_docker.sh'

### DIFF
--- a/maro/cli/maro_real_time_vis/start_maro_geo_vis.py
+++ b/maro/cli/maro_real_time_vis/start_maro_geo_vis.py
@@ -24,7 +24,8 @@ def start_geo_vis(start: str, experiment_name: str, front_end_port: int, **kwarg
         database_start_path = f"{grader_path}/streamit/server"
         subprocess.check_call(
             'sh run_docker.sh',
-            cwd=database_start_path
+            cwd=database_start_path,
+            shell=True
         )
     elif start == 'service':
         if experiment_name is None:
@@ -93,7 +94,8 @@ def start_geo_vis(start: str, experiment_name: str, front_end_port: int, **kwarg
 
         subprocess.check_call(
             'sh run_docker.sh',
-            cwd=exec_path
+            cwd=exec_path,
+            shell=True
         )
         back_end_path = f"{exec_path}/back_end/vis_app/app.py"
         os.system(f"python {back_end_path}")


### PR DESCRIPTION
# Description

I had an error while executing the "maro inspector geo --start database"，subprocess failed to execute 'sh run_docker.sh'
![image](https://user-images.githubusercontent.com/40318104/112970894-41761b00-9181-11eb-84ed-f5af5bc06cf2.png)
![image](https://user-images.githubusercontent.com/40318104/112970937-4b981980-9181-11eb-9bdf-a9adfabfe0cf.png)


## Type of Change

- [ ] Breaking bug fix


## Related Component

maro-real-time-vis

## Has Been Tested
sample test
- OS:
  - [ ] Linux
- Python version:
  - [ ] 3.7



