### PR TITLE
fixed lr scheduler init bug

### DIFF
--- a/maro/rl/model/learning_model.py
+++ b/maro/rl/model/learning_model.py
@@ -57,6 +57,7 @@ class AbsCoreModel(nn.Module):
         else:
             if isinstance(optim_option, dict):
                 self.optimizer = {}
+                self.scheduler = {}
                 for name, opt in optim_option.items():
                     self.optimizer[name] = opt.optim_cls(self._component[name].parameters(), **opt.optim_params)
                     if opt.scheduler_cls:


### PR DESCRIPTION
# Description

Fixed learning rate scheduler bug in AbsCoreModel: https://github.com/microsoft/maro/issues/356
(self.scheduler was used as a dictionary without defining it first)

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [x] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
