### PR TITLE
fix vessel plan, vessel past and future stops info in the snapshot list issue

### DIFF
--- a/maro/data_lib/cim/vessel_future_stops_prediction.py
+++ b/maro/data_lib/cim/vessel_future_stops_prediction.py
@@ -77,12 +77,13 @@ class VesselFutureStopsPrediction:
             arrive_tick += duration + ceil(distance / speed)
 
             predicted_future_stops.append(
-                Stop(-1,  # predict stop do not have valid index
-                     arrive_tick,
-                     arrive_tick + duration,
-                     port_idx,
-                     vessel_idx
-                     )
+                Stop(
+                    -1,  # predict stop do not have valid index
+                    arrive_tick,
+                    arrive_tick + duration,
+                    port_idx,
+                    vessel_idx
+                )
             )
 
         return predicted_future_stops

--- a/maro/data_lib/cim/vessel_future_stops_prediction.py
+++ b/maro/data_lib/cim/vessel_future_stops_prediction.py
@@ -32,15 +32,12 @@ class VesselFutureStopsPrediction:
 
         vessel_idx = key[0]
         last_loc_idx = key[1]
-        next_loc_idx = key[2]
+        loc_idx = key[2]
 
         # ignore current port if parking
-        start = next_loc_idx + (1 if last_loc_idx == next_loc_idx else 0)
+        last_stop_idx = loc_idx + (0 if last_loc_idx == loc_idx else -1)
 
-        if last_loc_idx != next_loc_idx:
-            start = start - 1
-
-        last_stop = self._stops[vessel_idx][start]
+        last_stop = self._stops[vessel_idx][last_stop_idx]
         last_port_idx = last_stop.port_idx
         last_port_arrive_tick = last_stop.arrive_tick
 

--- a/maro/data_lib/cim/vessel_past_stops_wrapper.py
+++ b/maro/data_lib/cim/vessel_past_stops_wrapper.py
@@ -25,15 +25,15 @@ class VesselPastStopsWrapper:
 
         vessel_idx = key[0]
         last_loc_idx = key[1]
-        next_loc_idx = key[2]
+        loc_idx = key[2]
 
         # ignore current port if parking
-        start = next_loc_idx + (1 if last_loc_idx == next_loc_idx else 0)
+        last_stop_idx = loc_idx + (0 if last_loc_idx == loc_idx else -1)
 
         # avoid negative index
-        start = max(next_loc_idx - self._stop_number, 0)
+        start = max(last_stop_idx - self._stop_number + 1, 0)
 
-        past_stop_list = self._stops[vessel_idx][start: next_loc_idx]
+        past_stop_list = self._stops[vessel_idx][start: loc_idx]
 
         # padding with None
         for _ in range(self._stop_number - len(past_stop_list)):

--- a/maro/simulator/scenarios/cim/vessel.py
+++ b/maro/simulator/scenarios/cim/vessel.py
@@ -92,8 +92,11 @@ def gen_vessel_definition(stop_nums: tuple):
                 future_stop_list (list): List of future stop list tuple.
             """
             # update past and future stop info
-            features = [(past_stop_list, self.past_stop_list, self.past_stop_tick_list),
-                        (future_stop_list, self.future_stop_list, self.future_stop_tick_list)]
+            features = []
+            if past_stop_list:
+                features.append((past_stop_list, self.past_stop_list, self.past_stop_tick_list))
+            if future_stop_list:
+                features.append((future_stop_list, self.future_stop_list, self.future_stop_tick_list))
 
             for feature in features:
                 for i, stop in enumerate(feature[0]):

--- a/tests/cim/test_cim_scenario.py
+++ b/tests/cim/test_cim_scenario.py
@@ -53,6 +53,8 @@ def mock_cim_init_func(self, event_buffer, topology_path, max_tick):
 
     self._load_departure_events()
 
+    self._init_vessel_plans()
+
 
 class TestCimScenarios(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
# Description

- Fix the past and future stops index calculation method.
- Move the vessel location index updates to the handler function for vessel arrival and vessel departure.
- Move the past and future stops info updates to handler function for vessel departure and vessel arrival respectively.
- Move the vessel plan update to the handler function for vessel arrival.
- Add an initialization function for vessel stops info and vessel plan, and call it in CIM BE initialization.
- Update the business engine initialization function for CIM scenario test respectively.

## Linked issue(s)/Pull request(s)

- Issue #360 

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
