### PR TITLE
add redis-server into dependency; update pulp solver used in example

### DIFF
--- a/examples/citi_bike/online_lp/citi_bike_ilp.py
+++ b/examples/citi_bike/online_lp/citi_bike_ilp.py
@@ -2,7 +2,7 @@ import math
 from typing import List, Tuple
 
 import numpy as np
-from pulp import GLPK, LpInteger, LpMaximize, LpProblem, LpVariable, lpSum
+from pulp import PULP_CBC_CMD, LpInteger, LpMaximize, LpProblem, LpVariable, lpSum
 
 from maro.utils import DottableDict
 
@@ -176,7 +176,7 @@ class CitiBikeILP():
         self._init_variables(init_inventory=init_inventory)
         self._add_constraints(problem=problem, demand=demand, supply=supply)
         self._set_objective(problem=problem)
-        problem.solve(GLPK(msg=0))
+        problem.solve(PULP_CBC_CMD(msg=0))
 
     # ============================= private end =============================
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -27,6 +27,7 @@ urllib3==1.26.5
 geopy==2.0.0
 pandas==0.25.3
 redis==3.5.3
+redis-server==6.0.9
 requests==2.25.1
 holidays==0.10.3
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
         "holidays>=0.10.3",
         "pyaml>=20.4.0",
         "redis>=3.5.3",
+        "redis-server>=6.0.6"
         "pyzmq<22.1.0",
         "requests<=2.26.0",
         "psutil<5.9.0",


### PR DESCRIPTION
# Description

* Add redis-server into dependency
* Change the pulp solver used in the example to the default one to avoid more package dependency

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
