### PR TITLE
change the input topology schema for CIM real data mode

### DIFF
--- a/maro/data_lib/cim/README.md
+++ b/maro/data_lib/cim/README.md
@@ -2,34 +2,19 @@
 
 Current the real data input are supported by the **CimRealDataLoader** and **CimRealDataContainer** implemented in *maro/data_lib/cim/cim_data_loader.py* and *maro/data_lib/cim/cim_data_container.py* respectively.
 
-## Configurations in the Topology File *config.yml*
+To build up a topology with real data as input, different to the synthetic mode, no need for any *config.yml* file,
+just put the input data files under the folder of the specific topology.
 
-To build up a topology with real data as input, 2 parts of configurations are required for the config.yml:
-
-- input_setting: describes what type of the input data files and where are the data files.
-- transfer_cost_factors: used by the business engine to calculate the transfer cost automatically.
-
-Here is an example for the *config.yml* file:
-
-```text
-input_setting:
-  from_files: true
-  input_type: real  # real, dumped
-  data_folder: "~\.maro\data\cim\test.new_schema"
-
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
-```
-
-## Input CSV Files
+## Input Data Files
 
 The required input data files includes: *misc.yml, orders.csv, ports.csv, routes.csv, stops.csv, vessels.csv*.
 
-The *misc.yml* file includes 5 settings, they are (for example):
+The *misc.yml* file includes 7 settings, they are (for example):
 ```text
 max_tick: 224
 container_volume: 1
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 past_stop_number: 4
 future_stop_number: 3
 seed: 4096

--- a/maro/data_lib/cim/cim_data_container.py
+++ b/maro/data_lib/cim/cim_data_container.py
@@ -77,6 +77,16 @@ class CimBaseDataContainer(ABC):
         return self._data_collection.future_stop_number
 
     @property
+    def load_cost_factor(self) -> float:
+        """float: Factor of the cost for each empty load."""
+        return self._data_collection.load_cost_factor
+
+    @property
+    def dsch_cost_factor(self) -> float:
+        """float: Factor of the cost for each empty discharge."""
+        return self._data_collection.dsch_cost_factor
+
+    @property
     def ports(self) -> List[PortSetting]:
         """List[PortSetting]: List of port initial settings."""
         return self._data_collection.ports_settings

--- a/maro/data_lib/cim/cim_data_container.py
+++ b/maro/data_lib/cim/cim_data_container.py
@@ -89,22 +89,22 @@ class CimBaseDataContainer(ABC):
     @property
     def ports(self) -> List[PortSetting]:
         """List[PortSetting]: List of port initial settings."""
-        return self._data_collection.ports_settings
+        return self._data_collection.port_settings
 
     @property
     def port_number(self) -> int:
         """int: Number of ports."""
-        return len(self._data_collection.ports_settings)
+        return len(self._data_collection.port_settings)
 
     @property
     def vessels(self) -> List[VesselSetting]:
         """List[VesselSetting]: List of vessel initial settings."""
-        return self._data_collection.vessels_settings
+        return self._data_collection.vessel_settings
 
     @property
     def vessel_number(self) -> int:
         """int: Number of vessels."""
-        return len(self._data_collection.vessels_settings)
+        return len(self._data_collection.vessel_settings)
 
     @property
     def container_volume(self) -> int:

--- a/maro/data_lib/cim/cim_data_container_helpers.py
+++ b/maro/data_lib/cim/cim_data_container_helpers.py
@@ -4,8 +4,6 @@
 import os
 import urllib.parse
 
-from yaml import safe_load
-
 from maro.cli.data_pipeline.utils import StaticParameter
 from maro.simulator.utils import seed
 

--- a/maro/data_lib/cim/cim_data_container_helpers.py
+++ b/maro/data_lib/cim/cim_data_container_helpers.py
@@ -31,18 +31,15 @@ class CimDataContainerWrapper:
         self._init_data_container()
 
     def _init_data_container(self):
-        # read config
-        with open(self._config_path, "r") as fp:
-            conf: dict = safe_load(fp)
-        if "input_setting" in conf and conf["input_setting"]["from_files"]:
-            if conf["input_setting"]["input_type"] == "real":
-                self._data_cntr = data_from_files(data_folder=conf["input_setting"]["data_folder"])
-            else:
-                self._data_cntr = data_from_dumps(dumps_folder=conf["input_setting"]["data_folder"])
-        else:
+        # Synthetic Data Mode: config.yml must exist.
+        config_path = os.path.join(self._config_path, "config.yml")
+        if os.path.exists(config_path):
             self._data_cntr = data_from_generator(
-                config_path=self._config_path, max_tick=self._max_tick, start_tick=self._start_tick
+                config_path=config_path, max_tick=self._max_tick, start_tick=self._start_tick
             )
+        else:
+            # Real Data Mode: read data from input data files, no need for any config.yml.
+            self._data_cntr = data_from_files(data_folder=self._config_path)
 
     def reset(self):
         """Reset data container internal state"""

--- a/maro/data_lib/cim/cim_data_container_helpers.py
+++ b/maro/data_lib/cim/cim_data_container_helpers.py
@@ -29,6 +29,8 @@ class CimDataContainerWrapper:
         self._init_data_container()
 
     def _init_data_container(self):
+        if not os.path.exists(self._config_path):
+            raise FileNotFoundError
         # Synthetic Data Mode: config.yml must exist.
         config_path = os.path.join(self._config_path, "config.yml")
         if os.path.exists(config_path):

--- a/maro/data_lib/cim/cim_data_dump.py
+++ b/maro/data_lib/cim/cim_data_dump.py
@@ -59,7 +59,7 @@ class CimDataDumpUtil:
         headers = ["vessel_name", "vessel_index", "port_name", "port_index", "arrival_tick", "departure_tick"]
 
         def stop_generator():
-            for vessel_stops in self._data_collection.vessels_stops:
+            for vessel_stops in self._data_collection.vessel_stops:
                 for stop in vessel_stops:
                     yield [
                         vessel_idx2name_dict[stop.vessel_idx],
@@ -85,7 +85,7 @@ class CimDataDumpUtil:
         ]
 
         def port_generator():
-            for port in self._data_collection.ports_settings:
+            for port in self._data_collection.port_settings:
                 yield [
                     port.index,
                     port.name,
@@ -116,7 +116,7 @@ class CimDataDumpUtil:
 
         route_mapping = self._data_collection.route_mapping
         port_mapping = self._data_collection.port_mapping
-        vessels = self._data_collection.vessels_settings
+        vessels = self._data_collection.vessel_settings
         vessel_period = self._data_collection.vessel_period_without_noise
 
         def vessel_generator():
@@ -175,7 +175,7 @@ class CimDataDumpUtil:
             "dest_port_index", "proportion", "proportion_noise"
         ]
 
-        ports = self._data_collection.ports_settings
+        ports = self._data_collection.port_settings
 
         def order_prop_generator():
             for port in ports:

--- a/maro/data_lib/cim/cim_data_dump.py
+++ b/maro/data_lib/cim/cim_data_dump.py
@@ -201,6 +201,8 @@ class CimDataDumpUtil:
             "past_stop_number": self._data_collection.past_stop_number,
             "future_stop_number": self._data_collection.future_stop_number,
             "container_volume": self._data_collection.container_volume,
+            "load_cost_factor": self._data_collection.load_cost_factor,
+            "dsch_cost_factor": self._data_collection.dsch_cost_factor,
             "max_tick": self._data_collection.max_tick,
             "seed": self._data_collection.seed,
             "version": self._data_collection.version

--- a/maro/data_lib/cim/cim_data_generator.py
+++ b/maro/data_lib/cim/cim_data_generator.py
@@ -54,7 +54,6 @@ class CimDataGenerator:
         total_containers = conf["total_containers"]
         past_stop_number, future_stop_number = conf["stop_number"]
         container_volumes = conf["container_volumes"]
-        order_mode = OrderGenerateMode(conf["order_generate_mode"])
 
         # parse configurations
         vessel_mapping, vessels_setting = self._vessels_parser.parse(conf["vessels"])
@@ -70,33 +69,37 @@ class CimDataGenerator:
 
         return CimSyntheticDataCollection(
             # Port
-            ports_setting,
-            port_mapping,
+            ports_settings=ports_setting,
+            port_mapping=port_mapping,
             # Vessel
-            vessels_setting,
-            vessel_mapping,
+            vessels_settings=vessels_setting,
+            vessel_mapping=vessel_mapping,
             # Stop
-            vessels_stops,
+            vessels_stops=vessels_stops,
             # Route
-            routes,
-            route_mapping,
+            routes=routes,
+            route_mapping=route_mapping,
             # Vessel Period
-            vessel_period_without_noise,
+            vessel_period_without_noise=vessel_period_without_noise,
             # Volume/Container
-            container_volumes[0],
+            container_volume=container_volumes[0],
+            # Cost Factors
+            load_cost_factor=conf["load_cost_factor"],
+            dsch_cost_factor=conf["dsch_cost_factor"],
             # Visible Voyage Window
-            past_stop_number,
-            future_stop_number,
+            past_stop_number=past_stop_number,
+            future_stop_number=future_stop_number,
             # Time Length of the Data Collection
-            max_tick,
+            max_tick=max_tick,
             # Random Seed for Data Generation
-            topology_seed,
+            seed=topology_seed,
             # For Order Generation
-            total_containers,
-            order_mode,
-            global_order_proportion,
+            total_containers=total_containers,
+            order_mode=OrderGenerateMode(conf["order_generate_mode"]),
+            order_proportion=global_order_proportion,
             # Data Generator Version
-            CIM_GENERATOR_VERSION)
+            version=CIM_GENERATOR_VERSION
+        )
 
     def _extend_route(
         self, future_stop_number: int, max_tick: int,

--- a/maro/data_lib/cim/cim_data_generator.py
+++ b/maro/data_lib/cim/cim_data_generator.py
@@ -64,7 +64,7 @@ class CimDataGenerator:
             total_containers, start_tick=start_tick, max_tick=max_tick)
 
         # extend routes with specified tick range
-        vessels_stops, vessel_period_without_noise = self._extend_route(
+        vessel_stops, vessel_period_without_noise = self._extend_route(
             future_stop_number, max_tick, vessels_setting, ports_setting, port_mapping, routes, route_mapping)
 
         return CimSyntheticDataCollection(
@@ -75,7 +75,7 @@ class CimDataGenerator:
             vessel_settings=vessels_setting,
             vessel_mapping=vessel_mapping,
             # Stop
-            vessel_stops=vessels_stops,
+            vessel_stops=vessel_stops,
             # Route
             routes=routes,
             route_mapping=route_mapping,
@@ -107,13 +107,13 @@ class CimDataGenerator:
     ) -> (List[List[Stop]], List[int]):
         """Extend route with specified tick range."""
 
-        vessels_stops: List[List[Stop]] = []
+        vessel_stops: List[List[Stop]] = []
         vessel_period_without_noise: List[int] = []
 
         # fill the result stops with empty list
         # NOTE: not using [[]] * N
         for _ in range(len(vessels_setting)):
-            vessels_stops.append([])
+            vessel_stops.append([])
 
         # extend for each vessel
         for vessel_setting in vessels_setting:
@@ -159,7 +159,7 @@ class CimDataGenerator:
                             vessel_setting.index)
 
                 # append to current vessels stops list
-                vessels_stops[vessel_setting.index].append(stop)
+                vessel_stops[vessel_setting.index].append(stop)
 
                 # use distance_to_next_port and speed (all with noise) to calculate tick of arrival and departure
                 distance_to_next_port = cur_route_point.distance_to_next_port
@@ -176,7 +176,7 @@ class CimDataGenerator:
 
                 # only add period at 1st route circle
                 period_no_noise += (whole_duration_no_noise if len(
-                    vessels_stops[vessel_setting.index]) <= route_length else 0)
+                    vessel_stops[vessel_setting.index]) <= route_length else 0)
 
                 # next location index
                 loc_idx_in_route = (loc_idx_in_route + 1) % route_length
@@ -188,4 +188,4 @@ class CimDataGenerator:
 
             vessel_period_without_noise.append(period_no_noise)
 
-        return vessels_stops, vessel_period_without_noise
+        return vessel_stops, vessel_period_without_noise

--- a/maro/data_lib/cim/cim_data_generator.py
+++ b/maro/data_lib/cim/cim_data_generator.py
@@ -69,13 +69,13 @@ class CimDataGenerator:
 
         return CimSyntheticDataCollection(
             # Port
-            ports_settings=ports_setting,
+            port_settings=ports_setting,
             port_mapping=port_mapping,
             # Vessel
-            vessels_settings=vessels_setting,
+            vessel_settings=vessels_setting,
             vessel_mapping=vessel_mapping,
             # Stop
-            vessels_stops=vessels_stops,
+            vessel_stops=vessels_stops,
             # Route
             routes=routes,
             route_mapping=route_mapping,

--- a/maro/data_lib/cim/cim_data_loader.py
+++ b/maro/data_lib/cim/cim_data_loader.py
@@ -206,9 +206,9 @@ class CimDumpDataLoader(CimBaseDataLoader):
         # construct data collection
         # NOTE: this is a namedtuple, so out-side cannot change it
         data_collection = CimSyntheticDataCollection(
-            ports_settings=ports,
+            port_settings=ports,
             port_mapping=port_mapping,
-            vessels_settings=vessels,
+            vessel_settings=vessels,
             vessel_mapping=vessel_mapping,
             vessel_stops=stops,
             routes=routes,
@@ -328,11 +328,11 @@ class CimRealDataLoader(CimBaseDataLoader):
         # construct data collection
         # NOTE: this is a namedtuple, so out-side cannot change it
         data_collection = CimRealDataCollection(
-            ports_settings=ports,
+            port_settings=ports,
             port_mapping=port_mapping,
-            vessels_settings=vessels,
+            vessel_settings=vessels,
             vessel_mapping=vessel_mapping,
-            vessels_stops=stops,
+            vessel_stops=stops,
             routes=routes,
             route_mapping=route_mapping,
             vessel_period_without_noise=periods_without_noise,

--- a/maro/data_lib/cim/cim_data_loader.py
+++ b/maro/data_lib/cim/cim_data_loader.py
@@ -206,23 +206,25 @@ class CimDumpDataLoader(CimBaseDataLoader):
         # construct data collection
         # NOTE: this is a namedtuple, so out-side cannot change it
         data_collection = CimSyntheticDataCollection(
-            ports,
-            port_mapping,
-            vessels,
-            vessel_mapping,
-            stops,
-            routes,
-            route_mapping,
-            periods_without_noise,
-            misc_items["container_volume"],
-            misc_items["past_stop_number"],
-            misc_items["future_stop_number"],
-            misc_items["max_tick"],
-            misc_items["seed"],
-            misc_items["total_container"],
-            OrderGenerateMode(misc_items["order_mode"]),
-            global_order_proportions,
-            misc_items["version"]
+            ports_settings=ports,
+            port_mapping=port_mapping,
+            vessels_settings=vessels,
+            vessel_mapping=vessel_mapping,
+            vessel_stops=stops,
+            routes=routes,
+            route_mapping=route_mapping,
+            vessel_period_without_noise=periods_without_noise,
+            container_volume=misc_items["container_volume"],
+            load_cost_factor=misc_items["load_cost_factor"],
+            dsch_cost_factor=misc_items["dsch_cost_factor"],
+            past_stop_number=misc_items["past_stop_number"],
+            future_stop_number=misc_items["future_stop_number"],
+            max_tick=misc_items["max_tick"],
+            seed=misc_items["seed"],
+            total_containers=misc_items["total_container"],
+            order_mode=OrderGenerateMode(misc_items["order_mode"]),
+            order_proportion=global_order_proportions,
+            version=misc_items["version"]
         )
 
         return data_collection
@@ -326,20 +328,22 @@ class CimRealDataLoader(CimBaseDataLoader):
         # construct data collection
         # NOTE: this is a namedtuple, so out-side cannot change it
         data_collection = CimRealDataCollection(
-            ports,
-            port_mapping,
-            vessels,
-            vessel_mapping,
-            stops,
-            routes,
-            route_mapping,
-            periods_without_noise,
-            misc_items["container_volume"],
-            misc_items["past_stop_number"],
-            misc_items["future_stop_number"],
-            misc_items["max_tick"],
-            misc_items["seed"],
-            orders
+            ports_settings=ports,
+            port_mapping=port_mapping,
+            vessels_settings=vessels,
+            vessel_mapping=vessel_mapping,
+            vessels_stops=stops,
+            routes=routes,
+            route_mapping=route_mapping,
+            vessel_period_without_noise=periods_without_noise,
+            container_volume=misc_items["container_volume"],
+            load_cost_factor=misc_items["load_cost_factor"],
+            dsch_cost_factor=misc_items["dsch_cost_factor"],
+            past_stop_number=misc_items["past_stop_number"],
+            future_stop_number=misc_items["future_stop_number"],
+            max_tick=misc_items["max_tick"],
+            seed=misc_items["seed"],
+            orders=orders
         )
 
         return data_collection

--- a/maro/data_lib/cim/entities.py
+++ b/maro/data_lib/cim/entities.py
@@ -108,13 +108,13 @@ class Order:
 @dataclass(frozen=True)
 class CimBaseDataCollection:
     # Port
-    ports_settings: List[PortSetting]
+    port_settings: List[PortSetting]
     port_mapping: Dict[str, int]
     # Vessel
-    vessels_settings: List[VesselSetting]
+    vessel_settings: List[VesselSetting]
     vessel_mapping: Dict[str, int]
     # Stop
-    vessels_stops: List[List[Stop]]
+    vessel_stops: List[List[Stop]]
     # Route
     routes: List[List[RoutePoint]]
     route_mapping: Dict[str, int]

--- a/maro/data_lib/cim/entities.py
+++ b/maro/data_lib/cim/entities.py
@@ -122,6 +122,9 @@ class CimBaseDataCollection:
     vessel_period_without_noise: List[int]
     # Volume/Container
     container_volume: int
+    # Cost Factors
+    load_cost_factor: float
+    dsch_cost_factor: float
     # Visible Voyage Window
     past_stop_number: int
     future_stop_number: int

--- a/maro/data_lib/cim/port_buffer_tick_wrapper.py
+++ b/maro/data_lib/cim/port_buffer_tick_wrapper.py
@@ -20,7 +20,7 @@ class PortBufferTickWrapper:
     """
 
     def __init__(self, data: CimBaseDataCollection, attribute_func: callable):
-        self._ports = data.ports_settings
+        self._ports = data.port_settings
         self._attribute_func = attribute_func
 
     def __getitem__(self, key):

--- a/maro/data_lib/cim/port_parser.py
+++ b/maro/data_lib/cim/port_parser.py
@@ -34,7 +34,7 @@ class PortsParser:
             ports_mapping[port_name] = index
             index += 1
 
-        ports_settings: List[SyntheticPortSetting] = []
+        port_settings: List[SyntheticPortSetting] = []
 
         for port_idx, port in enumerate(conf.items()):
             port_name, port_info = port
@@ -80,6 +80,6 @@ class PortsParser:
                     source_dist_conf["noise"]),
                 targets_dist)
 
-            ports_settings.append(port_setting)
+            port_settings.append(port_setting)
 
-        return ports_mapping, ports_settings
+        return ports_mapping, port_settings

--- a/maro/data_lib/cim/vessel_future_stops_prediction.py
+++ b/maro/data_lib/cim/vessel_future_stops_prediction.py
@@ -18,8 +18,8 @@ class VesselFutureStopsPrediction:
     """
 
     def __init__(self, data: CimBaseDataCollection):
-        self._vessels = data.vessels_settings
-        self._stops = data.vessels_stops
+        self._vessels = data.vessel_settings
+        self._stops = data.vessel_stops
         self._routes = data.routes
         self._route_mapping = data.route_mapping
         self._port_mapping = data.port_mapping

--- a/maro/data_lib/cim/vessel_past_stops_wrapper.py
+++ b/maro/data_lib/cim/vessel_past_stops_wrapper.py
@@ -17,7 +17,7 @@ class VesselPastStopsWrapper:
 
     def __init__(self, data: CimBaseDataCollection):
         self._stop_number = data.past_stop_number
-        self._stops = data.vessels_stops
+        self._stops = data.vessel_stops
 
     def __getitem__(self, key):
         assert type(key) == tuple or type(key) == list

--- a/maro/data_lib/cim/vessel_reachable_stops_wrapper.py
+++ b/maro/data_lib/cim/vessel_reachable_stops_wrapper.py
@@ -17,7 +17,7 @@ class VesselReachableStopsWrapper:
 
     def __init__(self, data: CimBaseDataCollection):
         self._routes = data.routes
-        self._stops = data.vessels_stops
+        self._stops = data.vessel_stops
 
     def __getitem__(self, key):
         assert type(key) == tuple or type(key) == list

--- a/maro/data_lib/cim/vessel_stop_wrapper.py
+++ b/maro/data_lib/cim/vessel_stop_wrapper.py
@@ -22,7 +22,7 @@ class VesselStopsWrapper:
     """
 
     def __init__(self, data: CimBaseDataCollection):
-        self._stops = data.vessels_stops
+        self._stops = data.vessel_stops
 
     def __getitem__(self, key):
         key_type = type(key)

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.0/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.0/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.1/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.1/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.2/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.2/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.3/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.3/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.4/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.4/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.5/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.5/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.6/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.6/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.7/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.7/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.8/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/global_trade.22p_l0.8/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.0/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.0/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.1/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.1/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.2/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.2/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.3/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.3/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.4/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.4/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.5/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.5/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.6/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.6/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.7/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.7/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.8/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.4p_ssdd_l0.8/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.0/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.0/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.1/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.1/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.2/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.2/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.3/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.3/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.4/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.4/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.5/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.5/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.6/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.6/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.7/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.7/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.8/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.5p_ssddd_l0.8/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.0/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.0/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.1/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.1/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.2/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.2/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.3/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.3/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.4/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.4/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.5/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.5/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.6/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.6/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.7/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.7/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.8/config.yml
+++ b/maro/simulator/scenarios/cim/topologies/toy.6p_sssbdd_l0.8/config.yml
@@ -1,7 +1,6 @@
 seed: 4096
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/tests/cim/data_generator/test_data_collection_load.py
+++ b/tests/cim/data_generator/test_data_collection_load.py
@@ -74,8 +74,8 @@ class TestDumpsLoad(unittest.TestCase):
                 self.assertTrue(p1.distance_to_next_port, p2.distance_to_next_port)
 
     def _compare_ports(self, dc1: CimSyntheticDataCollection, dc2: CimSyntheticDataCollection):
-        ports_1 = dc1.ports_settings
-        ports_2 = dc2.ports_settings
+        ports_1 = dc1.port_settings
+        ports_2 = dc2.port_settings
 
         self.assertTrue(len(ports_1) == len(ports_2))
 
@@ -104,8 +104,8 @@ class TestDumpsLoad(unittest.TestCase):
 
 
     def _compare_vessels(self, dc1: CimSyntheticDataCollection, dc2: CimSyntheticDataCollection):
-        vessels_1: List[VesselSetting] = dc1.vessels_settings
-        vessels_2: List[VesselSetting] = dc2.vessels_settings
+        vessels_1: List[VesselSetting] = dc1.vessel_settings
+        vessels_2: List[VesselSetting] = dc2.vessel_settings
 
         self.assertTrue(len(vessels_1) == len(vessels_2))
 
@@ -125,8 +125,8 @@ class TestDumpsLoad(unittest.TestCase):
 
 
     def _compare_stops(self, dc1: CimSyntheticDataCollection, dc2: CimSyntheticDataCollection):
-        stops_1: List[List[Stop]] = dc1.vessels_stops
-        stops_2: List[List[Stop]] = dc2.vessels_stops
+        stops_1: List[List[Stop]] = dc1.vessel_stops
+        stops_2: List[List[Stop]] = dc2.vessel_stops
 
         self.assertTrue(len(stops_1) == len(stops_2))
 

--- a/tests/cim/data_generator/test_data_generator.py
+++ b/tests/cim/data_generator/test_data_generator.py
@@ -26,24 +26,24 @@ class TestDataGenerator(unittest.TestCase):
         self.assertListEqual([0.02 * dc.total_containers] * MAX_TICK, list(dc.order_proportion))
 
         # there should be 4 ports
-        self.assertEqual(4, len(dc.ports_settings))
+        self.assertEqual(4, len(dc.port_settings))
 
         # and 5 vessels
-        self.assertEqual(5, len(dc.vessels_settings))
+        self.assertEqual(5, len(dc.vessel_settings))
 
         # check vessel capacity
-        self.assertListEqual([92400, 92400, 187600, 187600, 187600], [v.capacity for v in dc.vessels_settings])
-        self.assertListEqual([10] * 5, [v.sailing_speed for v in dc.vessels_settings])
-        self.assertListEqual([0] * 5, [v.sailing_noise for v in dc.vessels_settings])
-        self.assertListEqual([1] * 5, [v.parking_duration for v in dc.vessels_settings])
-        self.assertListEqual([0] * 5, [v.parking_noise for v in dc.vessels_settings])
+        self.assertListEqual([92400, 92400, 187600, 187600, 187600], [v.capacity for v in dc.vessel_settings])
+        self.assertListEqual([10] * 5, [v.sailing_speed for v in dc.vessel_settings])
+        self.assertListEqual([0] * 5, [v.sailing_noise for v in dc.vessel_settings])
+        self.assertListEqual([1] * 5, [v.parking_duration for v in dc.vessel_settings])
+        self.assertListEqual([0] * 5, [v.parking_noise for v in dc.vessel_settings])
 
         # empty of vessel should be 0 by default from configuration
-        self.assertListEqual([0] * 5, [v.empty for v in dc.vessels_settings])
+        self.assertListEqual([0] * 5, [v.empty for v in dc.vessel_settings])
 
         # port
-        self.assertListEqual([100000,100000, 1000000, 100000], [p.capacity for p in dc.ports_settings])
-        self.assertListEqual([0.25 * dc.total_containers] * 4, [p.empty for p in dc.ports_settings])
+        self.assertListEqual([100000,100000, 1000000, 100000], [p.capacity for p in dc.port_settings])
+        self.assertListEqual([0.25 * dc.total_containers] * 4, [p.empty for p in dc.port_settings])
 
         # TODO: more
 

--- a/tests/data/cim/customized_config/config.yml
+++ b/tests/data/cim/customized_config/config.yml
@@ -1,8 +1,7 @@
 
 seed: 123
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:

--- a/tests/data/cim/data_generator/dumps/config.yml
+++ b/tests/data/cim/data_generator/dumps/config.yml
@@ -1,7 +1,6 @@
 seed: 123
-transfer_cost_factors:
-  load: 0.05
-  dsch: 0.05
+load_cost_factor: 0.05
+dsch_cost_factor: 0.05
 container_usage_proportion:
   period: 112
   sample_nodes:


### PR DESCRIPTION
# Description

Requested by real data deployment process.

- CIM: move `load_cost_factor` and `dsch_cost_factor` from BE._config to BE._data_cntr
- CIM real data mode: remove the requirement for config.yml file, move the cost factors to misc file.
- CIM: update topologies correspondingly

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
