### PR TITLE
Fix the "Wrong future stop tick predictions" bug

### DIFF
--- a/maro/data_lib/cim/vessel_future_stops_prediction.py
+++ b/maro/data_lib/cim/vessel_future_stops_prediction.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from math import ceil
+from typing import List
 
 from .entities import CimBaseDataCollection, Stop
 
@@ -24,6 +25,7 @@ class VesselFutureStopsPrediction:
         self._route_mapping = data.route_mapping
         self._port_mapping = data.port_mapping
         self._stop_number = data.future_stop_number
+        self._vessel_start_port_offsets = self._make_vessel_start_port_offset()
 
     def __getitem__(self, key):
         """Used to support querying future stops by vessel index, last location index, next location index."""
@@ -37,41 +39,40 @@ class VesselFutureStopsPrediction:
         # ignore current port if parking
         last_stop_idx = loc_idx + (0 if last_loc_idx == loc_idx else -1)
 
-        last_stop = self._stops[vessel_idx][last_stop_idx]
-        last_port_idx = last_stop.port_idx
-        last_port_arrival_tick = last_stop.arrival_tick
+        return self._predict_future_stops(vessel_idx, last_stop_idx, self._stop_number)
 
-        return self._predict_future_stops(vessel_idx, last_port_idx, last_port_arrival_tick, self._stop_number)
+    def _make_vessel_start_port_offset(self) -> List[int]:
+        vessel_start_port_offsets = []
+        for vessel in self._vessels:
+            route_points = self._routes[self._route_mapping[vessel.route_name]]
+            route_point_names = [rp.port_name for rp in route_points]
+            vessel_start_port_offset = route_point_names.index(vessel.start_port_name)
+            vessel_start_port_offsets.append(vessel_start_port_offset)
+        return vessel_start_port_offsets
 
-    def _predict_future_stops(self, vessel_idx: int, last_port_idx: int, last_port_arrival_tick: int, stop_number: int):
+    def _predict_future_stops(self, vessel_idx: int, last_stop_idx: int, stop_number: int):
         """Do predict future stops.
         """
         vessel = self._vessels[vessel_idx]
-        speed = vessel.sailing_speed
-        duration = vessel.parking_duration
-        route_name = vessel.route_name
-        route_points = self._routes[self._route_mapping[route_name]]
+        speed, duration = vessel.sailing_speed, vessel.parking_duration
+        route_points = self._routes[self._route_mapping[vessel.route_name]]
         route_length = len(route_points)
 
-        last_loc_idx = -1
+        last_stop = self._stops[vessel_idx][last_stop_idx]
+        last_port_arrival_tick = last_stop.arrival_tick
 
-        # try to find the last location index from route
-        for loc_idx, route_point in enumerate(route_points):
-            if self._port_mapping[route_point.port_name] == last_port_idx:
-                last_loc_idx = loc_idx
-                break
-
-        # return if not in current route
-        if last_loc_idx < 0:
-            return []
+        vessel_start_port_offset = self._vessel_start_port_offsets[vessel_idx]
+        last_loc_idx = (vessel_start_port_offset + last_stop_idx) % len(route_points)
 
         predicted_future_stops = []
         arrival_tick = last_port_arrival_tick
 
         # predict from configured sailing plan, not from stops
         for loc_idx in range(last_loc_idx + 1, last_loc_idx + stop_number + 1):
-            route_info = route_points[loc_idx % route_length]
-            port_idx, distance_to_next_port = self._port_mapping[route_info.port_name], route_info.distance_to_next_port
+            next_route_info = route_points[loc_idx % route_length]
+            last_route_info = route_points[(loc_idx - 1) % route_length]
+            port_idx = self._port_mapping[next_route_info.port_name]
+            distance_to_next_port = last_route_info.distance_to_next_port
 
             # NO noise for speed
             arrival_tick += duration + ceil(distance_to_next_port / speed)

--- a/maro/data_lib/cim/vessel_sailing_plan_wrapper.py
+++ b/maro/data_lib/cim/vessel_sailing_plan_wrapper.py
@@ -30,11 +30,6 @@ class VesselSailingPlanWrapper(VesselFutureStopsPrediction):
 
         route_length = len(self._routes[route_idx])
 
-        last_stop: Stop = self._stops[vessel_idx][next_loc_idx]
-        last_port_idx = last_stop.port_idx
-        last_port_arrival_tick = last_stop.arrival_tick
-
-        stops = self._predict_future_stops(
-            vessel_idx, last_port_idx, last_port_arrival_tick, route_length)
+        stops = self._predict_future_stops(vessel_idx, next_loc_idx, route_length)
 
         return [(stop.port_idx, stop.arrival_tick) for stop in stops]

--- a/maro/data_lib/cim/vessel_sailing_plan_wrapper.py
+++ b/maro/data_lib/cim/vessel_sailing_plan_wrapper.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from .entities import CimBaseDataCollection, Stop
+from .entities import CimBaseDataCollection
 from .vessel_future_stops_prediction import VesselFutureStopsPrediction
 
 


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->

Fix the "Wrong future stop tick predictions" bug reported in issue [384](https://github.com/microsoft/maro/issues/384). Use "offset + step" method to fix & simply the calculation and simply the function interface accordingly.

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [384](https://github.com/microsoft/maro/issues/384)

## Type of Change

- [x] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [x] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [x] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [x] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [x] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [x] Update the dependent downstream modules usage
