### PR TITLE
change the default solver used in Citibike OnlineLP example, from GLPK to CBC

### DIFF
--- a/examples/citi_bike/online_lp/README.md
+++ b/examples/citi_bike/online_lp/README.md
@@ -1,5 +1,23 @@
 # Performance
 
+## Solver Used
+
+To get stable problem solution, the experiments are made with **GLPK solver**.
+To use GLPK solver, you need to first install the GLPK package in your platform
+accordingly. Then replace the *PULP_CBC_CMD* solver with GLPK in the code.
+
+```python
+from pulp import GLPK
+
+class CitiBikeILP():
+
+  def _formulate_and_solve(...):
+    ...
+    problem.solve(GLPK(msg=0))
+```
+
+## Configuration
+
 Below are the final environment metrics of the onlineLP in different topologies.
 For each experiment, we setup the environment and test for a duration of 1 week
 with environment random seed 0, 128, 1024.  Besides the parameter listed in the

--- a/examples/citi_bike/online_lp/citi_bike_ilp.py
+++ b/examples/citi_bike/online_lp/citi_bike_ilp.py
@@ -2,7 +2,7 @@ import math
 from typing import List, Tuple
 
 import numpy as np
-from pulp import GLPK, LpInteger, LpMaximize, LpProblem, LpVariable, lpSum
+from pulp import PULP_CBC_CMD, LpInteger, LpMaximize, LpProblem, LpVariable, lpSum
 
 from maro.utils import DottableDict
 
@@ -176,7 +176,7 @@ class CitiBikeILP():
         self._init_variables(init_inventory=init_inventory)
         self._add_constraints(problem=problem, demand=demand, supply=supply)
         self._set_objective(problem=problem)
-        problem.solve(GLPK(msg=0))
+        problem.solve(PULP_CBC_CMD(msg=0))
 
     # ============================= private end =============================
 


### PR DESCRIPTION
# Description

Since the PULP package will only enable the default CBC solver, change the default solver used in Citibike OnlineLP example, from GLPK to CBC

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
