### PR TITLE
Cim disable auto action type detection

### DIFF
--- a/docs/source/examples/multi_agent_dqn_cim.rst
+++ b/docs/source/examples/multi_agent_dqn_cim.rst
@@ -69,7 +69,7 @@ in the roll-out loop. In this example,
                 plan_action = percent * (scope.discharge + early_discharge) - early_discharge
                 actual_action = round(plan_action) if plan_action > 0 else round(percent * scope.discharge)
             else:
-                actual_action, action_type = 0, None
+                actual_action, action_type = 0, ActionType.LOAD
 
             return {port: Action(vessel, port, actual_action, action_type)}
 

--- a/docs/source/scenarios/container_inventory_management.rst
+++ b/docs/source/scenarios/container_inventory_management.rst
@@ -572,7 +572,7 @@ Once we get a ``DecisionEvent`` from the environment, we should respond with an
   * **vessel_idx** (int): The id of the vessel/operation object of the port/agent.
   * **port_idx** (int): The id of the port/agent that take this action.
   * **action_type** (ActionType): Whether to load or discharge empty containers in this action.
-  * **quantity** (int): The quantity of empty containers to be loaded/discharged.
+  * **quantity** (int): The (non-negative) quantity of empty containers to be loaded/discharged.
 
 Example
 ^^^^^^^

--- a/examples/cim/common.py
+++ b/examples/cim/common.py
@@ -30,7 +30,7 @@ class CIMTrajectory(Trajectory):
     def __init__(
         self, env, *, port_attributes, vessel_attributes, action_space, look_back, max_ports_downstream,
         reward_time_window, fulfillment_factor, shortage_factor, time_decay,
-        finite_vessel_space=True, has_early_discharge=True 
+        finite_vessel_space=True, has_early_discharge=True
     ):
         super().__init__(env)
         self.port_attributes = port_attributes
@@ -72,7 +72,7 @@ class CIMTrajectory(Trajectory):
             plan_action = percent * (scope.discharge + early_discharge) - early_discharge
             actual_action = round(plan_action) if plan_action > 0 else round(percent * scope.discharge)
         else:
-            actual_action, action_type = 0, None
+            actual_action, action_type = 0, ActionType.LOAD
 
         return {port: Action(vessel, port, actual_action, action_type)}
 

--- a/maro/simulator/scenarios/cim/business_engine.py
+++ b/maro/simulator/scenarios/cim/business_engine.py
@@ -668,9 +668,6 @@ class CimBusinessEngine(AbsBusinessEngine):
 
                 action_type: ActionType = getattr(action, "action_type", None)
 
-                # Make sure the move number is positive, as we have the action type.
-                move_num = abs(move_num)
-
                 if action_type == ActionType.DISCHARGE:
                     assert(move_num <= vessel_empty)
 

--- a/maro/simulator/scenarios/cim/business_engine.py
+++ b/maro/simulator/scenarios/cim/business_engine.py
@@ -668,10 +668,6 @@ class CimBusinessEngine(AbsBusinessEngine):
 
                 action_type: ActionType = getattr(action, "action_type", None)
 
-                # Make it compatible with previous action.
-                if action_type is None:
-                    action_type = ActionType.DISCHARGE if move_num > 0 else ActionType.LOAD
-
                 # Make sure the move number is positive, as we have the action type.
                 move_num = abs(move_num)
 

--- a/maro/simulator/scenarios/cim/business_engine.py
+++ b/maro/simulator/scenarios/cim/business_engine.py
@@ -666,7 +666,8 @@ class CimBusinessEngine(AbsBusinessEngine):
                 port_empty = port.empty
                 vessel_empty = vessel.empty
 
-                action_type: ActionType = getattr(action, "action_type", None)
+                assert isinstance(action, Action)
+                action_type = action.action_type
 
                 if action_type == ActionType.DISCHARGE:
                     assert(move_num <= vessel_empty)

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -26,18 +26,20 @@ class Action:
     Args:
         vessel_idx (int): Which vessel will take action.
         port_idx (int): Which port will take action.
-        action_type (Optional[ActionType]): Whether the action is a Load or a Discharge.
+        action_type (ActionType): Whether the action is a Load or a Discharge.
             If None, the action type will be automatically detected according to quantity.
         quantity (int): How many containers are loaded/discharged in this Action.
     """
 
     summary_key = ["port_idx", "vessel_idx", "action_type", "quantity"]
 
-    def __init__(self, vessel_idx: int, port_idx: int, quantity: int, action_type: Optional[ActionType]):
+    def __init__(self, vessel_idx: int, port_idx: int, quantity: int, action_type: ActionType):
+        assert action_type is not None
+
         self.vessel_idx: int = vessel_idx
         self.port_idx: int = port_idx
         self.quantity: int = quantity
-        self.action_type: Optional[ActionType] = action_type
+        self.action_type: ActionType = action_type
 
     def __repr__(self):
         return "%s {action_type: %r, port_idx: %r, vessel_idx: %r, quantity: %r}" % \

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -3,7 +3,6 @@
 
 
 from enum import Enum, IntEnum
-from typing import Optional
 
 from maro.backends.frame import SnapshotList
 

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -40,9 +40,17 @@ class Action:
         self.quantity: int = quantity
         self.action_type: ActionType = action_type
 
+        assert self._is_valid_action_type()
+
     def __repr__(self):
         return "%s {action_type: %r, port_idx: %r, vessel_idx: %r, quantity: %r}" % \
             (self.__class__.__name__, str(self.action_type), self.port_idx, self.vessel_idx, self.quantity)
+
+    def _is_valid_action_type(self) -> bool:
+        if self.action_type == ActionType.DISCHARGE:
+            return self.quantity > 0
+        else:
+            return self.quantity <= 0
 
 
 class ActionScope:

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -33,25 +33,16 @@ class Action:
 
     def __init__(self, vessel_idx: int, port_idx: int, quantity: int, action_type: ActionType):
         assert action_type is not None
+        assert quantity >= 0
 
         self.vessel_idx: int = vessel_idx
         self.port_idx: int = port_idx
         self.quantity: int = quantity
         self.action_type: ActionType = action_type
 
-        assert self._is_valid_action_type()
-
     def __repr__(self):
         return "%s {action_type: %r, port_idx: %r, vessel_idx: %r, quantity: %r}" % \
             (self.__class__.__name__, str(self.action_type), self.port_idx, self.vessel_idx, self.quantity)
-
-    def _is_valid_action_type(self) -> bool:
-        if self.action_type == ActionType.DISCHARGE:
-            return self.quantity > 0
-        elif self.action_type == ActionType.LOAD:
-            return self.quantity <= 0
-        else:
-            raise ValueError(f"Invalid Action type: {self.action_type}")
 
 
 class ActionScope:

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -27,7 +27,6 @@ class Action:
         vessel_idx (int): Which vessel will take action.
         port_idx (int): Which port will take action.
         action_type (ActionType): Whether the action is a Load or a Discharge.
-            If None, the action type will be automatically detected according to quantity.
         quantity (int): How many containers are loaded/discharged in this Action.
     """
 

--- a/maro/simulator/scenarios/cim/common.py
+++ b/maro/simulator/scenarios/cim/common.py
@@ -49,8 +49,10 @@ class Action:
     def _is_valid_action_type(self) -> bool:
         if self.action_type == ActionType.DISCHARGE:
             return self.quantity > 0
-        else:
+        elif self.action_type == ActionType.LOAD:
             return self.quantity <= 0
+        else:
+            raise ValueError(f"Invalid Action type: {self.action_type}")
 
 
 class ActionScope:

--- a/notebooks/container_inventory_management/interact_with_environment.ipynb
+++ b/notebooks/container_inventory_management/interact_with_environment.ipynb
@@ -311,7 +311,7 @@
     "   - **vessel_idx**: (int) The id of the vessel/operation object of the port/agent;\n",
     "   - **port_idx**: (int) The id of the port/agent that take this action;\n",
     "   - **action_type**: (ActionType) Whether to load or discharge empty containers in this action;\n",
-    "   - **quantity**: (int) The quantity of empty containers to be loaded/discharged.\n",
+    "   - **quantity**: (int) The (non-negative) quantity of empty containers to be loaded/discharged.\n",
     "\n",
     "## Generate random actions based on the DecisionEvent\n",
     "\n",

--- a/notebooks/container_inventory_management/rl_formulation.ipynb
+++ b/notebooks/container_inventory_management/rl_formulation.ipynb
@@ -101,7 +101,7 @@
     "            plan_action = percent * (scope.discharge + early_discharge) - early_discharge\n",
     "            actual_action = round(plan_action) if plan_action > 0 else round(percent * scope.discharge)\n",
     "        else:\n",
-    "            actual_action, action_type = 0, None\n",
+    "            actual_action, action_type = 0, ActionType.LOAD\n",
     "\n",
     "        return {port: Action(vessel, port, actual_action, action_type)}\n",
     "\n",

--- a/tests/cim/new_test_cim_scenario.py
+++ b/tests/cim/new_test_cim_scenario.py
@@ -336,7 +336,7 @@ class TestCimScenarios(unittest.TestCase):
             load_action = Action(
                 vessel_idx=decision_event.vessel_idx,
                 port_idx=decision_event.port_idx,
-                quantity=-1201,
+                quantity=1201,
                 action_type=ActionType.LOAD
             )
             discharge_action = Action(

--- a/tests/cim/new_test_cim_scenario.py
+++ b/tests/cim/new_test_cim_scenario.py
@@ -17,7 +17,7 @@ from maro.data_lib.cim import dump_from_config
 from maro.data_lib.cim.entities import PortSetting, Stop, SyntheticPortSetting, VesselSetting
 from maro.data_lib.cim.vessel_stop_wrapper import VesselStopsWrapper
 from maro.simulator import Env
-from maro.simulator.scenarios.cim.common import Action, DecisionEvent
+from maro.simulator.scenarios.cim.common import Action, ActionType, DecisionEvent
 from maro.simulator.scenarios.cim.ports_order_export import PortOrderExporter
 from tests.utils import backends_to_test, compare_dictionary
 
@@ -337,13 +337,13 @@ class TestCimScenarios(unittest.TestCase):
                 vessel_idx=decision_event.vessel_idx,
                 port_idx=decision_event.port_idx,
                 quantity=-1201,
-                action_type=None  # Automatic type detection will be triggered
+                action_type=ActionType.LOAD
             )
             discharge_action = Action(
                 vessel_idx=decision_event.vessel_idx,
                 port_idx=decision_event.port_idx,
                 quantity=1,
-                action_type=None  # Automatic type detection will be triggered
+                action_type=ActionType.DISCHARGE
             )
             metric, decision_event, is_done = self._env.step([load_action, discharge_action])
 


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->

Disable auto detection for `ActionType`. Users should present the action type (`LOAD` or `DISCHARGE`) explicitly.

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [x] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [x] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [x] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [x] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
