### PR TITLE
replace GLOBAL ORDER COUNTER with GLOBAL ORDER ID GENERATOR; add rese…

### DIFF
--- a/maro/data_lib/oncall_routing/data_loader.py
+++ b/maro/data_lib/oncall_routing/data_loader.py
@@ -7,7 +7,9 @@ from typing import Dict, List, Tuple
 import pandas as pd
 from yaml import safe_load
 
-from maro.simulator.scenarios.oncall_routing import GLOBAL_ORDER_COUNTER, PLAN_RAND_KEY, Coordinate, Order, PlanElement
+from maro.simulator.scenarios.oncall_routing import (
+    GLOBAL_ORDER_ID_GENERATOR, PLAN_RAND_KEY, Coordinate, Order, PlanElement
+)
 from maro.simulator.utils import random
 from maro.utils import DottableDict
 
@@ -26,7 +28,7 @@ def _load_plan_simple(csv_path: str, start_tick: int, end_tick: int) -> Dict[str
         for e in data.to_dict(orient='records'):
             # TODO
             order = Order(
-                order_id=str(next(GLOBAL_ORDER_COUNTER)),
+                order_id=next(GLOBAL_ORDER_ID_GENERATOR),
                 coordinate=Coordinate(e["LAT"], e["LNG"]),
                 open_time=start_tick,
                 close_time=end_tick,
@@ -116,7 +118,7 @@ class DeprecatedSamplePlanLoader(PlanLoader):
             plan = []
             for coord in coords:
                 order = Order(
-                    order_id=str(next(GLOBAL_ORDER_COUNTER)),
+                    order_id=next(GLOBAL_ORDER_ID_GENERATOR),
                     coordinate=coord,
                     open_time=self._start_tick,
                     close_time=self._end_tick

--- a/maro/data_lib/oncall_routing/oncall_order_generator.py
+++ b/maro/data_lib/oncall_routing/oncall_order_generator.py
@@ -8,7 +8,7 @@ from typing import Deque, List, Tuple
 import pandas as pd
 from yaml import safe_load
 
-from maro.simulator.scenarios.oncall_routing import GLOBAL_ORDER_COUNTER, ONCALL_RAND_KEY, Coordinate, Order
+from maro.simulator.scenarios.oncall_routing import GLOBAL_ORDER_ID_GENERATOR, ONCALL_RAND_KEY, Coordinate, Order
 from maro.simulator.utils import random
 from maro.utils import DottableDict
 
@@ -46,7 +46,7 @@ class FromHistoryOncallOrderGenerator(OncallOrderGenerator):
         buff = []
         for e in df.to_dict(orient='records'):
             order = Order(
-                order_id=str(next(GLOBAL_ORDER_COUNTER)),
+                order_id=next(GLOBAL_ORDER_ID_GENERATOR),
                 coordinate=Coordinate(e["LAT"], e["LNG"]),
                 open_time=convert_time_format(e["READYTIME"]),
                 close_time=convert_time_format(e["CLOSETIME"]),
@@ -106,7 +106,7 @@ class SampleOncallOrderGenerator(OncallOrderGenerator):
         buff = []
         for i in range(n):
             order = Order(
-                order_id=str(next(GLOBAL_ORDER_COUNTER)),
+                order_id=next(GLOBAL_ORDER_ID_GENERATOR),
                 coordinate=coords[i],
                 open_time=open_times[i],
                 close_time=close_times[i],

--- a/maro/simulator/scenarios/oncall_routing/__init__.py
+++ b/maro/simulator/scenarios/oncall_routing/__init__.py
@@ -3,11 +3,11 @@
 
 from .common import PlanElement
 from .coordinate import Coordinate
-from .order import GLOBAL_ORDER_COUNTER, Order
+from .order import GLOBAL_ORDER_ID_GENERATOR, Order
 from .utils import EST_RAND_KEY, GLOBAL_RAND_KEY, ONCALL_RAND_KEY, PLAN_RAND_KEY
 
 __all__ = [
     "Coordinate", "PlanElement",
-    "GLOBAL_ORDER_COUNTER", "Order",
+    "GLOBAL_ORDER_ID_GENERATOR", "Order",
     "EST_RAND_KEY", "GLOBAL_RAND_KEY", "ONCALL_RAND_KEY", "PLAN_RAND_KEY"
 ]

--- a/maro/simulator/scenarios/oncall_routing/common.py
+++ b/maro/simulator/scenarios/oncall_routing/common.py
@@ -31,7 +31,6 @@ class OncallReceivePayload:
 @dataclass
 class CarrierArrivalPayload:
     carrier_idx: int
-    # TODO: carrier name, route name, detailed stop info?
 
 
 @dataclass

--- a/maro/simulator/scenarios/oncall_routing/duration_time_predictor.py
+++ b/maro/simulator/scenarios/oncall_routing/duration_time_predictor.py
@@ -26,6 +26,9 @@ class EstimatedDurationPredictor:
         distance = geo_distance_meter(source_coordinate, target_coordinate)
         return math.ceil(max(1.0, distance / 200.0))  # TODO: fake
 
+    def reset(self):
+        pass
+
 
 class ActualDurationSampler:
     def sample(
@@ -40,3 +43,6 @@ class ActualDurationSampler:
         variance = estimated_arrival_time * 0.1
         noise = random[EST_RAND_KEY].normalvariate(mu=0.0, sigma=variance)
         return math.ceil(max(1.0, noise + estimated_arrival_time))  # TODO: fake
+
+    def reset(self):
+        pass

--- a/maro/simulator/scenarios/oncall_routing/order.py
+++ b/maro/simulator/scenarios/oncall_routing/order.py
@@ -9,11 +9,36 @@ from maro.utils import DottableDict
 
 from .coordinate import Coordinate
 
-GLOBAL_ORDER_COUNTER = count()
+
+class OrderIdGenerator(object):
+    __instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls.__instance is None:
+            cls.__instance = super(OrderIdGenerator, cls).__new__(cls, *args, **kwargs)
+        return cls.__instance
+
+    def __init__(self) -> None:
+        self._counter = count()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> str:
+        return str(next(self._counter))
+
+    def next(self):
+        return self.__next__()
+
+    def reset(self):
+        self._counter = count()
+
+
+GLOBAL_ORDER_ID_GENERATOR = OrderIdGenerator()
 
 
 class OrderStatus(Enum):
-    NOT_READY = "order not ready yet"   # TODO: add the carrier waiting event, wait till ready
+    NOT_READY = "order not ready yet"
     READY_IN_ADVANCE = "order not reach the open time but ready for service"
     IN_PROCESS = "order in process"
     IN_PROCESS_BUT_DELAYED = "order in process but delayed"


### PR DESCRIPTION
# Description

- replace GLOBAL ORDER COUNTER with GLOBAL ORDER ID GENERATOR;
- add reset function for predictors

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
