### PR TITLE
add order sorting at the beginning of simulation; fix order time window issue

### DIFF
--- a/examples/oncall_routing/hello.py
+++ b/examples/oncall_routing/hello.py
@@ -7,7 +7,7 @@ from maro.simulator.scenarios.oncall_routing.common import OncallRoutingPayload
 
 if __name__ == "__main__":
     env = Env(
-        scenario="oncall_routing", topology="example", start_tick=0, durations=1000,
+        scenario="oncall_routing", topology="example", start_tick=0, durations=1440,
         # options={"config_path": "C:/workspace/fedex_topology/example_sample/"}
     )
 

--- a/maro/data_lib/oncall_routing/data_loader.py
+++ b/maro/data_lib/oncall_routing/data_loader.py
@@ -13,6 +13,8 @@ from maro.simulator.scenarios.oncall_routing import (
 from maro.simulator.utils import random
 from maro.utils import DottableDict
 
+from .utils import convert_time_format
+
 
 def _load_plan_simple(csv_path: str, start_tick: int, end_tick: int) -> Dict[str, List[PlanElement]]:
     print(f"Loading routes data from {csv_path}.")
@@ -30,8 +32,8 @@ def _load_plan_simple(csv_path: str, start_tick: int, end_tick: int) -> Dict[str
             order = Order(
                 order_id=next(GLOBAL_ORDER_ID_GENERATOR),
                 coordinate=Coordinate(e["LAT"], e["LNG"]),
-                open_time=start_tick,
-                close_time=end_tick,
+                open_time=start_tick if e["IS_DELIVERY"] else convert_time_format(int(e["READYTIME"])),
+                close_time=end_tick if e["IS_DELIVERY"] else convert_time_format(int(e["CLOSETIME"])),
                 is_delivery=e["IS_DELIVERY"]
             )
 

--- a/maro/data_lib/oncall_routing/oncall_order_generator.py
+++ b/maro/data_lib/oncall_routing/oncall_order_generator.py
@@ -12,6 +12,7 @@ from maro.simulator.scenarios.oncall_routing import GLOBAL_ORDER_ID_GENERATOR, O
 from maro.simulator.utils import random
 from maro.utils import DottableDict
 
+from .utils import convert_time_format
 
 class OncallOrderGenerator(object):
     def __init__(self) -> None:
@@ -32,10 +33,6 @@ class OncallOrderGenerator(object):
             _, order = self._queue.popleft()
             orders.append(order)
         return orders
-
-
-def convert_time_format(t: int) -> int:
-    return (t // 100) * 60 + (t % 100)
 
 
 class FromHistoryOncallOrderGenerator(OncallOrderGenerator):

--- a/maro/data_lib/oncall_routing/utils.py
+++ b/maro/data_lib/oncall_routing/utils.py
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+def convert_time_format(t: int) -> int:
+    return (t // 100) * 60 + (t % 100)


### PR DESCRIPTION
# Description

- add order sorting at the beginning of simulation;
- fix order time window issue

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
