### PR TITLE
Delete singleton order id generator. Use seperate order id generator for data loader & oncall generator.

### DIFF
--- a/examples/oncall_routing/hello.py
+++ b/examples/oncall_routing/hello.py
@@ -8,7 +8,7 @@ from maro.simulator.scenarios.oncall_routing.common import OncallRoutingPayload
 if __name__ == "__main__":
     env = Env(
         scenario="oncall_routing", topology="example", start_tick=0, durations=1440,
-        # options={"config_path": "C:/workspace/fedex_topology/example_sample/"}
+        options={"config_path": "C:/workspace/fedex_topology/example_sample/"}
     )
 
     # TODO: check the reset functionality

--- a/examples/oncall_routing/hello.py
+++ b/examples/oncall_routing/hello.py
@@ -8,7 +8,6 @@ from maro.simulator.scenarios.oncall_routing.common import OncallRoutingPayload
 if __name__ == "__main__":
     env = Env(
         scenario="oncall_routing", topology="example", start_tick=0, durations=1440,
-        options={"config_path": "C:/workspace/fedex_topology/example_sample/"}
     )
 
     # TODO: check the reset functionality

--- a/maro/simulator/scenarios/oncall_routing/__init__.py
+++ b/maro/simulator/scenarios/oncall_routing/__init__.py
@@ -2,13 +2,13 @@
 # Licensed under the MIT license.
 
 from .coordinate import Coordinate
-from .order import GLOBAL_ORDER_ID_GENERATOR, Order
+from .order import Order, OrderIdGenerator
 from .plan_element import PlanElement
 from .route import Route
 from .utils import EST_RAND_KEY, GLOBAL_RAND_KEY, ONCALL_RAND_KEY, PLAN_RAND_KEY
 
 __all__ = [
     "Coordinate", "PlanElement",
-    "GLOBAL_ORDER_ID_GENERATOR", "Order", "Route",
+    "Order", "Route", "OrderIdGenerator",
     "EST_RAND_KEY", "GLOBAL_RAND_KEY", "ONCALL_RAND_KEY", "PLAN_RAND_KEY"
 ]

--- a/maro/simulator/scenarios/oncall_routing/business_engine.py
+++ b/maro/simulator/scenarios/oncall_routing/business_engine.py
@@ -23,7 +23,7 @@ from .common import (
 from .coordinate import Coordinate
 from .duration_time_predictor import ActualDurationSampler, EstimatedDurationPredictor
 from .frame_builder import gen_oncall_routing_frame
-from .order import GLOBAL_ORDER_ID_GENERATOR, Order, OrderStatus
+from .order import Order, OrderStatus
 from .plan_element import PlanElement
 from .route import Route
 from .utils import GLOBAL_RAND_KEY
@@ -150,7 +150,7 @@ class OncallRoutingBusinessEngine(AbsBusinessEngine):
         # TODO: fake head quarter order
         # The DUMMY order that represents the return-to-building event
         rtb_order = Order(
-            order_id=next(GLOBAL_ORDER_ID_GENERATOR),
+            order_id="dummy_rtb_order",
             coordinate=Coordinate(lat=self._config.station.latitude, lng=self._config.station.longitude),
             open_time=self._config.data_loader_config.start_tick,
             close_time=self._config.data_loader_config.end_tick,
@@ -278,7 +278,6 @@ class OncallRoutingBusinessEngine(AbsBusinessEngine):
         random.seed(new_seed)
 
         # Step 2
-        GLOBAL_ORDER_ID_GENERATOR.reset()
         self._oncall_order_generator.reset()
         self._oncall_order_buffer.clear()
 

--- a/maro/simulator/scenarios/oncall_routing/order.py
+++ b/maro/simulator/scenarios/oncall_routing/order.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 from enum import Enum
-from itertools import count
 from typing import Optional
 
 from maro.utils import DottableDict
@@ -11,30 +10,16 @@ from .coordinate import Coordinate
 
 
 class OrderIdGenerator(object):
-    __instance = None
+    def __init__(self, prefix: str) -> None:
+        self._prefix = prefix
+        self._count = 0
 
-    def __new__(cls, *args, **kwargs):
-        if cls.__instance is None:
-            cls.__instance = super(OrderIdGenerator, cls).__new__(cls, *args, **kwargs)
-        return cls.__instance
+    def reset(self, reset_to: int = 0) -> None:
+        self._count = reset_to
 
-    def __init__(self) -> None:
-        self._counter = count()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self) -> str:
-        return str(next(self._counter))
-
-    def next(self):
-        return self.__next__()
-
-    def reset(self):
-        self._counter = count()
-
-
-GLOBAL_ORDER_ID_GENERATOR = OrderIdGenerator()
+    def next(self) -> str:
+        self._count += 1
+        return "{}_{:04d}".format(self._prefix, self._count - 1)
 
 
 class OrderStatus(Enum):


### PR DESCRIPTION
…for data loader & oncall generator.

# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->
Delete singleton order id generator. Use seperate order id generator for data loader & oncall generator.

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
