### PR TITLE
update greedy baseline; fix tick parameter not correct issue

### DIFF
--- a/examples/oncall_routing/greedy.py
+++ b/examples/oncall_routing/greedy.py
@@ -7,24 +7,10 @@ from maro.simulator import Env
 from maro.simulator.scenarios.oncall_routing.common import Action, OncallRoutingPayload
 from maro.utils import set_seeds
 
+from examples.oncall_routing.utils import refresh_segment_index
+
 set_seeds(0)
 
-
-def _is_equal_segment(action1: Action, action2: Action) -> bool:
-    return (action1.route_name, action1.insert_index) == (action2.route_name, action2.insert_index)
-
-def _refresh_segment_index(actions: List[Action]) -> List[Action]:
-    # Add segment index if multiple orders are sharing a same insert index.
-    actions.sort(key=lambda action: (action.route_name, action.insert_index))
-    segment_index = 0
-    for idx in range(len(actions) - 1):
-        if _is_equal_segment(actions[idx], actions[idx + 1]):
-            segment_index += 1
-            actions[idx + 1].in_segment_order = segment_index
-        else:
-            segment_index = 0
-
-    return actions
 
 def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
     tick = running_env.tick
@@ -54,7 +40,7 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
         if chosen_route_name is not None:
             actions.append(Action(order_id=oncall_order.id, route_name=chosen_route_name, insert_index=insert_idx))
 
-    actions = _refresh_segment_index(actions)
+    actions = refresh_segment_index(actions)
 
     return actions
 

--- a/examples/oncall_routing/greedy.py
+++ b/examples/oncall_routing/greedy.py
@@ -1,43 +1,58 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from maro.simulator import Env
-from maro.simulator.scenarios.oncall_routing import Order, Route
 from maro.simulator.scenarios.oncall_routing.common import Action, OncallRoutingPayload
-from maro.simulator.scenarios.oncall_routing.utils import geo_distance_meter
 from maro.utils import set_seeds
 
 set_seeds(0)
 
 
-def get_greedy_action(
-    order: Order,
-    route_meta_info_dict: dict,
-    route_plan_dict: Dict[str, List[Order]],
-    carriers_in_stop: List[bool]
-) -> Optional[Action]:
-    min_distance: float = float("inf")
-    insert_index: int = -1
-    chosen_route_name: Optional[str] = None
+def _is_equal_segment(action1: Action, action2: Action) -> bool:
+    return (action1.route_name, action1.insert_index) == (action2.route_name, action2.insert_index)
 
-    for route_name in route_meta_info_dict:
-        carrier_idx = route_meta_info_dict[route_name]["carrier_idx"]
-        start = 0 if carriers_in_stop[carrier_idx] else 1
-        plan = route_plan_dict[route_name]
 
-        for i in range(start, len(plan)):
-            distance = geo_distance_meter(order.coord, plan[i].coord)
-            if distance < min_distance:
-                min_distance = distance
-                chosen_route_name = route_name
-                insert_index = i
+def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
+    tick = running_env.tick
+    oncall_orders = event.oncall_orders
+    route_meta_info_dict = event.route_meta_info_dict
+    route_plan_dict = event.route_plan_dict
+    carriers_in_stop: List[bool] = (running_env.snapshot_list["carriers"][tick::"in_stop"] == 1).tolist()
+    est_duration_predictor = event.estimated_duration_predictor
 
-    if chosen_route_name is None:
-        return None
+    actions = []
+    for oncall_order in oncall_orders:
+        min_distance = float("inf")
+        chosen_route_name: Optional[str] = None
+        insert_idx = -1
 
-    return Action(order_id=order.id, route_name=chosen_route_name, insert_index=insert_index)
+        for route_name, meta in route_meta_info_dict.items():
+            carrier_idx = meta["carrier_idx"]
+            planned_orders = route_plan_dict[route_name]
+
+            for i, planned_order in enumerate(planned_orders):
+                if i == 0 and not carriers_in_stop[carrier_idx]:
+                    continue
+                distance = est_duration_predictor.predict(tick, oncall_order.coord, planned_order.coord)
+                if distance < min_distance:
+                    min_distance, chosen_route_name, insert_idx = distance, route_name, i
+
+        if chosen_route_name is not None:
+            actions.append(Action(order_id=oncall_order.id, route_name=chosen_route_name, insert_index=insert_idx))
+
+    # Add segment index if multiple orders are share
+    actions.sort(key=lambda action: (action.route_name, action.insert_index))
+    segment_index = 0
+    for idx in range(len(actions) - 1):
+        if _is_equal_segment(actions[idx], actions[idx + 1]):
+            segment_index += 1
+            actions[idx + 1].in_segment_order = segment_index
+        else:
+            segment_index = 0
+
+    return actions
 
 
 # Greedy: assign each on-call order to the closest stop on existing route.
@@ -50,29 +65,7 @@ if __name__ == "__main__":
     metrics, decision_event, is_done = env.step(None)
     while not is_done:
         assert isinstance(decision_event, OncallRoutingPayload)
-        orders = decision_event.oncall_orders
-        route_plan_dict = decision_event.route_plan_dict
-        carriers_in_stop: List[bool] = (env.snapshot_list["carriers"][env.tick::"in_stop"] == 1).tolist()
-        route_meta_info_dict = decision_event.route_meta_info_dict
-
-        # Call get_action one by one to get the action without considering segment index
-        actions: List[Action] = [get_greedy_action(
-            order, route_meta_info_dict, route_plan_dict, carriers_in_stop
-        ) for order in orders]
-        actions = [action for action in actions if action]
-        # Add segment index if multiple orders are share
-        actions = sorted(actions, key=lambda action: (action.route_name, action.insert_index))
-        segment_index = 0
-        for idx in range(len(actions) - 1):
-            if (
-                actions[idx + 1].route_name == actions[idx].route_name
-                and actions[idx + 1].insert_index == actions[idx].insert_index
-            ):
-                segment_index += 1
-                actions[idx + 1].in_segment_order = segment_index
-            else:
-                segment_index = 0
-
-        metrics, decision_event, is_done = env.step(actions)
+        print(f"Processing {len(decision_event.oncall_orders)} oncall orders at tick {env.tick}.")
+        metrics, decision_event, is_done = env.step(_get_actions(env, decision_event))
 
     print(metrics)

--- a/examples/oncall_routing/greedy_with_time_window.py
+++ b/examples/oncall_routing/greedy_with_time_window.py
@@ -30,11 +30,11 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
 
     actions = []
     for oncall_order in oncall_orders:
-        # Best result without violating any time windows
+        # Best result with violating any time windows
         min_distance_violate = float("inf")
         chosen_route_name_violate: Optional[str] = None
         insert_idx_violate = -1
-        # Best result with violating time windows
+        # Best result without violating time windows
         min_distance_no_violate = float("inf")
         chosen_route_name_no_violate: Optional[str] = None
         insert_idx_no_violate = -1

--- a/examples/oncall_routing/greedy_with_time_window.py
+++ b/examples/oncall_routing/greedy_with_time_window.py
@@ -86,7 +86,10 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
                             )
 
                     # Violate current planned order time window
-                    if not planned_orders[j].open_time <= cur_tick <= planned_orders[j].close_time:
+                    if all([
+                        duration is not None,
+                        not planned_orders[j].open_time <= cur_tick <= planned_orders[j].close_time
+                    ]):
                         is_time_valid = False
                         break
 

--- a/examples/oncall_routing/greedy_with_time_window.py
+++ b/examples/oncall_routing/greedy_with_time_window.py
@@ -8,24 +8,10 @@ from maro.simulator.scenarios.oncall_routing import Coordinate
 from maro.simulator.scenarios.oncall_routing.common import Action, OncallRoutingPayload
 from maro.utils import set_seeds
 
+from examples.oncall_routing.utils import refresh_segment_index
+
 set_seeds(0)
 
-
-def _is_equal_segment(action1: Action, action2: Action) -> bool:
-    return (action1.route_name, action1.insert_index) == (action2.route_name, action2.insert_index)
-
-def _refresh_segment_index(actions: List[Action]) -> List[Action]:
-    # Add segment index if multiple orders are sharing a same insert index.
-    actions.sort(key=lambda action: (action.route_name, action.insert_index))
-    segment_index = 0
-    for idx in range(len(actions) - 1):
-        if _is_equal_segment(actions[idx], actions[idx + 1]):
-            segment_index += 1
-            actions[idx + 1].in_segment_order = segment_index
-        else:
-            segment_index = 0
-
-    return actions
 
 def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
     tick = running_env.tick
@@ -140,7 +126,7 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
                 insert_idx_violate, route_original_indexes[chosen_route_name_violate][insert_idx_violate]
             )
 
-    actions = _refresh_segment_index(actions)
+    actions = refresh_segment_index(actions)
 
     return actions
 

--- a/examples/oncall_routing/greedy_with_time_window.py
+++ b/examples/oncall_routing/greedy_with_time_window.py
@@ -14,6 +14,18 @@ set_seeds(0)
 def _is_equal_segment(action1: Action, action2: Action) -> bool:
     return (action1.route_name, action1.insert_index) == (action2.route_name, action2.insert_index)
 
+def _refresh_segment_index(actions: List[Action]) -> List[Action]:
+    # Add segment index if multiple orders are sharing a same insert index.
+    actions.sort(key=lambda action: (action.route_name, action.insert_index))
+    segment_index = 0
+    for idx in range(len(actions) - 1):
+        if _is_equal_segment(actions[idx], actions[idx + 1]):
+            segment_index += 1
+            actions[idx + 1].in_segment_order = segment_index
+        else:
+            segment_index = 0
+
+    return actions
 
 def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
     tick = running_env.tick
@@ -30,12 +42,13 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
 
     actions = []
     for oncall_order in oncall_orders:
-        # Best result with violating any time windows
-        min_distance_violate = float("inf")
+        # Best result with violating time windows
+        min_duration_violate = float("inf")
         chosen_route_name_violate: Optional[str] = None
         insert_idx_violate = -1
-        # Best result without violating time windows
-        min_distance_no_violate = float("inf")
+
+        # Best result without violating any time windows
+        min_duration_no_violate = float("inf")
         chosen_route_name_no_violate: Optional[str] = None
         insert_idx_no_violate = -1
 
@@ -44,58 +57,64 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
             estimated_next_departure_tick: int = meta["estimated_next_departure_tick"]
             planned_orders = route_plan_dict[route_name]
 
-            for i, planned_order in enumerate(planned_orders):
+            for i, planned_order in enumerate(planned_orders):  # To traverse the insert index
                 if i == 0 and not carriers_in_stop[carrier_idx]:
                     continue
-                distance = est_duration_predictor.predict(tick, oncall_order.coord, planned_order.coord)
 
-                # Check if it will break any violate any time window
+                duration = None
+
+                # Check if it will violate any time window
                 is_time_valid = True
                 cur_tick = tick
                 for j in range(len(planned_orders)):  # Simulate all orders
                     if j == i:  # If we need to insert the oncall order before the j'th planned order
                         if j == 0:  # Carrier in stop. Insert before the first stop.
                             current_staying_stop_coordinate: Coordinate = meta["current_staying_stop_coordinate"]
+                            cur_tick += estimated_next_departure_tick
                             cur_tick += est_duration_predictor.predict(  # Current stop => oncall order
                                 cur_tick, current_staying_stop_coordinate, oncall_order.coord)
-                            cur_tick += estimated_next_departure_tick
                         else:
                             cur_tick += est_duration_predictor.predict(  # Last planned order => oncall order
                                 cur_tick, planned_orders[j - 1].coord, oncall_order.coord
                             )
-                        # Violate oncall order time window
+
+                        duration = est_duration_predictor.predict(cur_tick, oncall_order.coord, planned_order.coord)
+
+                        # Check if violate the oncall order time window or not
                         if not oncall_order.open_time <= cur_tick <= oncall_order.close_time:
                             is_time_valid = False
                             break
 
-                        cur_tick += est_duration_predictor.predict(  # Oncall order => current planned order
-                            cur_tick, oncall_order.coord, planned_orders[j].coord
-                        )
+                        cur_tick += duration  # Oncall order => current planned order
+
                     else:
                         if j == 0:
-                            estimated_duration_to_the_next_stop: int = meta["estimated_duration_to_the_next_stop"]
-                            if carriers_in_stop[carrier_idx]:  # Current stop => first planned order
-                                cur_tick += estimated_duration_to_the_next_stop
-                                cur_tick += estimated_next_departure_tick
-                            else:
-                                cur_tick += estimated_duration_to_the_next_stop
+                            # Current position (on the way or in a stop) => first planned order
+                            if carriers_in_stop[carrier_idx]:
+                                cur_tick = estimated_next_departure_tick
+                            cur_tick += meta["estimated_duration_to_the_next_stop"]
                         else:
-                            cur_tick += est_duration_predictor.predict(  # Last planned order => current planned order
+                            # Last planned order => current planned order
+                            cur_tick += est_duration_predictor.predict(
                                 cur_tick, planned_orders[j - 1].coord, planned_orders[j].coord
                             )
+
                     # Violate current planned order time window
                     if not planned_orders[j].open_time <= cur_tick <= planned_orders[j].close_time:
                         is_time_valid = False
                         break
 
+                if not duration:
+                    continue
+
                 if is_time_valid:
-                    if distance < min_distance_no_violate:
-                        min_distance_no_violate = distance
+                    if duration < min_duration_no_violate:
+                        min_duration_no_violate = duration
                         chosen_route_name_no_violate = route_name
                         insert_idx_no_violate = i
                 else:
-                    if distance < min_distance_violate:
-                        min_distance_violate = distance
+                    if duration < min_duration_violate:
+                        min_duration_violate = duration
                         chosen_route_name_violate = route_name
                         insert_idx_violate = i
 
@@ -109,6 +128,7 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
             route_original_indexes[chosen_route_name_no_violate].insert(
                 insert_idx_no_violate, route_original_indexes[chosen_route_name_no_violate][insert_idx_no_violate]
             )
+
         elif chosen_route_name_violate is not None:
             actions.append(Action(
                 order_id=oncall_order.id,
@@ -120,15 +140,7 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
                 insert_idx_violate, route_original_indexes[chosen_route_name_violate][insert_idx_violate]
             )
 
-    # Add segment index if multiple orders are share
-    actions.sort(key=lambda action: (action.route_name, action.insert_index))
-    segment_index = 0
-    for idx in range(len(actions) - 1):
-        if _is_equal_segment(actions[idx], actions[idx + 1]):
-            segment_index += 1
-            actions[idx + 1].in_segment_order = segment_index
-        else:
-            segment_index = 0
+    actions = _refresh_segment_index(actions)
 
     return actions
 

--- a/examples/oncall_routing/greedy_with_time_window.py
+++ b/examples/oncall_routing/greedy_with_time_window.py
@@ -1,0 +1,149 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import List, Optional
+
+from maro.simulator import Env
+from maro.simulator.scenarios.oncall_routing import Coordinate
+from maro.simulator.scenarios.oncall_routing.common import Action, OncallRoutingPayload
+from maro.utils import set_seeds
+
+set_seeds(0)
+
+
+def _is_equal_segment(action1: Action, action2: Action) -> bool:
+    return (action1.route_name, action1.insert_index) == (action2.route_name, action2.insert_index)
+
+
+def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
+    tick = running_env.tick
+    oncall_orders = event.oncall_orders
+    route_meta_info_dict = event.route_meta_info_dict
+    route_plan_dict = event.route_plan_dict
+    carriers_in_stop: List[bool] = (running_env.snapshot_list["carriers"][tick::"in_stop"] == 1).tolist()
+    est_duration_predictor = event.estimated_duration_predictor
+
+    route_original_indexes = {}
+    for route_name in route_meta_info_dict:
+        num_order = len(route_plan_dict[route_name])
+        route_original_indexes[route_name] = list(range(num_order))
+
+    actions = []
+    for oncall_order in oncall_orders:
+        # Best result without violating any time windows
+        min_distance_violate = float("inf")
+        chosen_route_name_violate: Optional[str] = None
+        insert_idx_violate = -1
+        # Best result with violating time windows
+        min_distance_no_violate = float("inf")
+        chosen_route_name_no_violate: Optional[str] = None
+        insert_idx_no_violate = -1
+
+        for route_name, meta in route_meta_info_dict.items():
+            carrier_idx = meta["carrier_idx"]
+            estimated_next_departure_tick: int = meta["estimated_next_departure_tick"]
+            planned_orders = route_plan_dict[route_name]
+
+            for i, planned_order in enumerate(planned_orders):
+                if i == 0 and not carriers_in_stop[carrier_idx]:
+                    continue
+                distance = est_duration_predictor.predict(tick, oncall_order.coord, planned_order.coord)
+
+                # Check if it will break any violate any time window
+                is_time_valid = True
+                cur_tick = tick
+                for j in range(len(planned_orders)):  # Simulate all orders
+                    if j == i:  # If we need to insert the oncall order before the j'th planned order
+                        if j == 0:  # Carrier in stop. Insert before the first stop.
+                            current_staying_stop_coordinate: Coordinate = meta["current_staying_stop_coordinate"]
+                            cur_tick += est_duration_predictor.predict(  # Current stop => oncall order
+                                cur_tick, current_staying_stop_coordinate, oncall_order.coord)
+                            cur_tick += estimated_next_departure_tick
+                        else:
+                            cur_tick += est_duration_predictor.predict(  # Last planned order => oncall order
+                                cur_tick, planned_orders[j - 1].coord, oncall_order.coord
+                            )
+                        # Violate oncall order time window
+                        if not oncall_order.open_time <= cur_tick <= oncall_order.close_time:
+                            is_time_valid = False
+                            break
+
+                        cur_tick += est_duration_predictor.predict(  # Oncall order => current planned order
+                            cur_tick, oncall_order.coord, planned_orders[j].coord
+                        )
+                    else:
+                        if j == 0:
+                            estimated_duration_to_the_next_stop: int = meta["estimated_duration_to_the_next_stop"]
+                            if carriers_in_stop[carrier_idx]:  # Current stop => first planned order
+                                cur_tick += estimated_duration_to_the_next_stop
+                                cur_tick += estimated_next_departure_tick
+                            else:
+                                cur_tick += estimated_duration_to_the_next_stop
+                        else:
+                            cur_tick += est_duration_predictor.predict(  # Last planned order => current planned order
+                                cur_tick, planned_orders[j - 1].coord, planned_orders[j].coord
+                            )
+                    # Violate current planned order time window
+                    if not planned_orders[j].open_time <= cur_tick <= planned_orders[j].close_time:
+                        is_time_valid = False
+                        break
+
+                if is_time_valid:
+                    if distance < min_distance_no_violate:
+                        min_distance_no_violate = distance
+                        chosen_route_name_no_violate = route_name
+                        insert_idx_no_violate = i
+                else:
+                    if distance < min_distance_violate:
+                        min_distance_violate = distance
+                        chosen_route_name_violate = route_name
+                        insert_idx_violate = i
+
+        if chosen_route_name_no_violate is not None:
+            actions.append(Action(
+                order_id=oncall_order.id,
+                route_name=chosen_route_name_no_violate,
+                insert_index=route_original_indexes[chosen_route_name_no_violate][insert_idx_no_violate]
+            ))
+            route_plan_dict[chosen_route_name_no_violate].insert(insert_idx_no_violate, oncall_order)
+            route_original_indexes[chosen_route_name_no_violate].insert(
+                insert_idx_no_violate, route_original_indexes[chosen_route_name_no_violate][insert_idx_no_violate]
+            )
+        elif chosen_route_name_violate is not None:
+            actions.append(Action(
+                order_id=oncall_order.id,
+                route_name=chosen_route_name_violate,
+                insert_index=route_original_indexes[chosen_route_name_violate][insert_idx_violate]
+            ))
+            route_plan_dict[chosen_route_name_violate].insert(insert_idx_violate, oncall_order)
+            route_original_indexes[chosen_route_name_violate].insert(
+                insert_idx_violate, route_original_indexes[chosen_route_name_violate][insert_idx_violate]
+            )
+
+    # Add segment index if multiple orders are share
+    actions.sort(key=lambda action: (action.route_name, action.insert_index))
+    segment_index = 0
+    for idx in range(len(actions) - 1):
+        if _is_equal_segment(actions[idx], actions[idx + 1]):
+            segment_index += 1
+            actions[idx + 1].in_segment_order = segment_index
+        else:
+            segment_index = 0
+
+    return actions
+
+
+# Greedy: assign each on-call order to the closest stop on existing route.
+if __name__ == "__main__":
+    env = Env(
+        scenario="oncall_routing", topology="example", start_tick=0, durations=1440,
+    )
+
+    env.reset(keep_seed=True)
+    metrics, decision_event, is_done = env.step(None)
+    while not is_done:
+        assert isinstance(decision_event, OncallRoutingPayload)
+        print(f"Processing {len(decision_event.oncall_orders)} oncall orders at tick {env.tick}.")
+        metrics, decision_event, is_done = env.step(_get_actions(env, decision_event))
+
+    print(metrics)

--- a/examples/oncall_routing/uniformly.py
+++ b/examples/oncall_routing/uniformly.py
@@ -9,6 +9,8 @@ from maro.simulator.scenarios.oncall_routing import Order
 from maro.simulator.scenarios.oncall_routing.common import Action, OncallRoutingPayload
 from maro.utils import set_seeds
 
+from examples.oncall_routing.utils import refresh_segment_index
+
 set_seeds(0)
 
 
@@ -61,18 +63,7 @@ if __name__ == "__main__":
             order, route_meta_info_dict, route_plan_dict, carriers_in_stop
         ) for order in orders]
         actions = [action for action in actions if action]
-        # Add segment index if multiple orders are share
-        actions = sorted(actions, key=lambda action: (action.route_name, action.insert_index))
-        segment_index = 0
-        for idx in range(len(actions) - 1):
-            if (
-                actions[idx + 1].route_name == actions[idx].route_name
-                and actions[idx + 1].insert_index == actions[idx].insert_index
-            ):
-                segment_index += 1
-                actions[idx + 1].in_segment_order = segment_index
-            else:
-                segment_index = 0
+        actions = refresh_segment_index(actions)
 
         metrics, decision_event, is_done = env.step(actions)
 

--- a/examples/oncall_routing/utils.py
+++ b/examples/oncall_routing/utils.py
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import List
+
+from maro.simulator.scenarios.oncall_routing.common import Action
+
+
+def refresh_segment_index(actions: List[Action]) -> List[Action]:
+    # Add segment index if multiple orders are sharing a same insert index.
+
+    def _is_equal_segment(action1: Action, action2: Action) -> bool:
+        return (action1.route_name, action1.insert_index) == (action2.route_name, action2.insert_index)
+
+    actions.sort(key=lambda action: (action.route_name, action.insert_index))
+    segment_index = 0
+    for idx in range(len(actions) - 1):
+        if _is_equal_segment(actions[idx], actions[idx + 1]):
+            segment_index += 1
+            actions[idx + 1].in_segment_order = segment_index
+        else:
+            segment_index = 0
+
+    return actions


### PR DESCRIPTION
# Description

- rename `distance` to `duration`
- extract the part for segment index update to an independent function
- update comments
- fix the `tick` parameter for predictor not correct issue
- fix wrong `cur_tick` update issue

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
