### PR TITLE
Redesign experience recording logic

### DIFF
--- a/maro/rl_v3/learning/env_sampler.py
+++ b/maro/rl_v3/learning/env_sampler.py
@@ -172,7 +172,7 @@ class ExpElement:
             ret[trainer_name].action_dict[agent_name] = self.action_dict[agent_name]
             ret[trainer_name].reward_dict[agent_name] = self.reward_dict[agent_name]
             ret[trainer_name].terminal_dict[agent_name] = self.terminal_dict[agent_name]
-            if self.next_agent_state_dict is not None:
+            if self.next_agent_state_dict is not None and agent_name in self.next_agent_state_dict:
                 ret[trainer_name].next_agent_state_dict[agent_name] = self.next_agent_state_dict[agent_name]
         return ret
 

--- a/maro/rl_v3/learning/env_sampler.py
+++ b/maro/rl_v3/learning/env_sampler.py
@@ -122,8 +122,7 @@ class SimpleAgentWrapper(AbsAgentWrapper):
 
 @dataclass
 class CacheElement:
-    """
-    The data structure used to store a cached value during experience collection.
+    """The data structure used to store a cached value during experience collection.
     """
     tick: int
     state: np.ndarray
@@ -133,10 +132,13 @@ class CacheElement:
 
 
 @dataclass
-class ExpElement(CacheElement):
+class ExpElement:
+    """Stores the complete information for a tick. ExpElement is an extension of CacheElement.
     """
-    Stores the complete information for a tick. ExpElement is an extension of CacheElement.
-    """
+    tick: int
+    state: np.ndarray
+    agent_state_dict: Dict[Any, np.ndarray]
+    action_dict: Dict[Any, np.ndarray]
     reward_dict: Dict[Any, float]
     terminal_dict: Dict[Any, bool]
     next_state: Optional[np.ndarray]
@@ -314,7 +316,6 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
                 state=cache_element.state,
                 agent_state_dict=cache_element.agent_state_dict,
                 action_dict=cache_element.action_dict,
-                env_action_dict=cache_element.env_action_dict,
                 reward_dict=reward_dict,
                 terminal_dict={},  # Will be processed later in `_post_polish_experiences()`
                 next_state=next_state,
@@ -343,7 +344,7 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
             for key, value in latest_agent_state_dict.items():
                 if key not in experiences[i].next_agent_state_dict:
                     experiences[i].next_agent_state_dict[key] = value
-            latest_agent_state_dict.update(experiences[i].next_agent_state_dict)
+            latest_agent_state_dict.update(experiences[i].agent_state_dict)
         return experiences
 
     def set_policy_states(self, policy_state_dict: Dict[str, object]) -> None:

--- a/maro/rl_v3/learning/env_sampler.py
+++ b/maro/rl_v3/learning/env_sampler.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import collections
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict, deque
 from dataclasses import dataclass
@@ -143,6 +146,35 @@ class ExpElement:
     terminal_dict: Dict[Any, bool]
     next_state: Optional[np.ndarray]
     next_agent_state_dict: Optional[Dict[Any, np.ndarray]]
+
+    @property
+    def agent_names(self) -> list:
+        return sorted(self.agent_state_dict.keys())
+
+    @property
+    def num_agents(self) -> int:
+        return len(self.agent_state_dict)
+
+    def split_contents(self, agent2trainer: Dict[Any, str]) -> Dict[str, ExpElement]:
+        ret = collections.defaultdict(lambda: ExpElement(
+            tick=self.tick,
+            state=self.state,
+            agent_state_dict={},
+            action_dict={},
+            reward_dict={},
+            terminal_dict={},
+            next_state=self.next_state,
+            next_agent_state_dict=None if self.next_agent_state_dict is None else {}
+        ))
+        for agent_name in self.agent_names:
+            trainer_name = agent2trainer[agent_name]
+            ret[trainer_name].agent_state_dict[agent_name] = self.agent_state_dict[agent_name]
+            ret[trainer_name].action_dict[agent_name] = self.action_dict[agent_name]
+            ret[trainer_name].reward_dict[agent_name] = self.reward_dict[agent_name]
+            ret[trainer_name].terminal_dict[agent_name] = self.terminal_dict[agent_name]
+            if self.next_agent_state_dict is not None:
+                ret[trainer_name].next_agent_state_dict[agent_name] = self.next_agent_state_dict[agent_name]
+        return ret
 
 
 class AbsEnvSampler(object, metaclass=ABCMeta):

--- a/maro/rl_v3/model/multi_q_net.py
+++ b/maro/rl_v3/model/multi_q_net.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import torch
 
-from maro.rl_v3.utils import match_shape, SHAPE_CHECK_FLAG
+from maro.rl_v3.utils import SHAPE_CHECK_FLAG, match_shape
 
 from .abs_net import AbsNet
 

--- a/maro/rl_v3/tmp_example_multi/main.py
+++ b/maro/rl_v3/tmp_example_multi/main.py
@@ -8,7 +8,6 @@ from .config import algorithm, env_conf, running_mode
 from .env_sampler import CIMEnvSampler
 from .policies import policy_creator, trainer_creator
 
-
 if __name__ == "__main__":
     run_workflow_centralized_mode(
         get_env_sampler_func=lambda: CIMEnvSampler(

--- a/maro/rl_v3/training/algorithms/ac.py
+++ b/maro/rl_v3/training/algorithms/ac.py
@@ -2,12 +2,14 @@
 # Licensed under the MIT license.
 
 import asyncio
+import collections
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional
 
 import numpy as np
 import torch
 
+from maro.rl_v3.learning import ExpElement
 from maro.rl_v3.model import VNet
 from maro.rl_v3.policy import DiscretePolicyGradient
 from maro.rl_v3.training import AbsTrainOps, FIFOReplayMemory, SingleTrainer, TrainerParams
@@ -198,22 +200,39 @@ class DiscreteActorCritic(SingleTrainer):
         self._params = params
         self._ops_name = f"{self._name}.ops"
 
+        self._policy_state_dim = self._ops.policy_state_dim
+        self._policy_action_dim = self._ops.policy_action_dim
+        self._replay_memory_dict = collections.defaultdict(lambda: FIFOReplayMemory(
+            capacity=self._params.replay_memory_capacity,
+            state_dim=self._policy_state_dim,
+            action_dim=self._policy_action_dim
+        ))
+
     def build(self) -> None:
         self._ops_params = {
             "get_policy_func": self._get_policy_func,
             **self._params.extract_ops_params(),
         }
-
         self._ops = self.get_ops(self._ops_name)
-        self._replay_memory = FIFOReplayMemory(
-            capacity=self._params.replay_memory_capacity,
-            state_dim=self._ops.policy_state_dim,
-            action_dim=self._ops.policy_action_dim
-        )
+
+    def record_new(self, exp_element: ExpElement) -> None:
+        for agent_name in exp_element.agent_names:
+            memory = self._replay_memory_dict[agent_name]
+            memory.put_new(
+                states=np.expand_dims(exp_element.agent_state_dict[agent_name], axis=0),
+                actions=np.expand_dims(exp_element.action_dict[agent_name], axis=0),
+                rewards=np.array([exp_element.reward_dict[agent_name]]),
+                terminals=np.array([exp_element.terminal_dict[agent_name]]),
+                next_states=np.expand_dims(exp_element.next_agent_state_dict[agent_name], axis=0),
+            )
 
     def _get_local_ops_by_name(self, ops_name: str) -> AbsTrainOps:
         return DiscreteActorCriticOps(**self._ops_params)
 
+    def _get_batch(self, agent_name: str, batch_size: int = None) -> TransitionBatch:
+        return self._replay_memory_dict[agent_name].sample(batch_size if batch_size is not None else self._batch_size)
+
     async def train_step(self):
-        await asyncio.gather(self._ops.set_batch(self._get_batch()))
-        await asyncio.gather(self._ops.update(self._params.grad_iters))
+        for agent_name in self._replay_memory_dict:
+            await asyncio.gather(self._ops.set_batch(self._get_batch(agent_name)))
+            await asyncio.gather(self._ops.update(self._params.grad_iters))

--- a/maro/rl_v3/training/algorithms/ddpg.py
+++ b/maro/rl_v3/training/algorithms/ddpg.py
@@ -11,7 +11,7 @@ import torch
 from maro.rl_v3.model import QNet
 from maro.rl_v3.policy import ContinuousRLPolicy
 from maro.rl_v3.training import AbsTrainOps, RandomReplayMemory, SingleTrainer, TrainerParams
-from maro.rl_v3.utils import ndarray_to_tensor, TransitionBatch
+from maro.rl_v3.utils import TransitionBatch, ndarray_to_tensor
 from maro.utils import clone
 
 

--- a/maro/rl_v3/training/algorithms/ddpg.py
+++ b/maro/rl_v3/training/algorithms/ddpg.py
@@ -11,7 +11,7 @@ import torch
 from maro.rl_v3.model import QNet
 from maro.rl_v3.policy import ContinuousRLPolicy
 from maro.rl_v3.training import AbsTrainOps, RandomReplayMemory, SingleTrainer, TrainerParams
-from maro.rl_v3.utils import CoroutineWrapper, TransitionBatch, ndarray_to_tensor
+from maro.rl_v3.utils import ndarray_to_tensor, TransitionBatch
 from maro.utils import clone
 
 

--- a/maro/rl_v3/training/replay_memory.py
+++ b/maro/rl_v3/training/replay_memory.py
@@ -137,43 +137,6 @@ class ReplayMemory(AbsReplayMemory, metaclass=ABCMeta):
     def action_dim(self) -> int:
         return self._action_dim
 
-    def put_new(
-        self,
-        states: np.ndarray,
-        actions: np.ndarray,
-        rewards: np.ndarray,
-        terminals: np.ndarray,
-        next_states: np.ndarray,
-    ) -> None:
-        batch_size = len(states)
-        if SHAPE_CHECK_FLAG:
-            assert 0 < batch_size <= self._capacity
-            assert match_shape(states, (batch_size, self._state_dim))
-            assert match_shape(actions, (batch_size, self._action_dim))
-            assert match_shape(rewards, (batch_size,))
-            assert match_shape(terminals, (batch_size,))
-            assert match_shape(next_states, (batch_size, self._state_dim))
-
-        self._put_by_indexes_new(
-            self._get_put_indexes(batch_size),
-            states, actions, rewards, terminals, next_states
-        )
-
-    def _put_by_indexes_new(
-        self,
-        indexes: np.ndarray,
-        states: np.ndarray,
-        actions: np.ndarray,
-        rewards: np.ndarray,
-        terminals: np.ndarray,
-        next_states: np.ndarray,
-    ) -> None:
-        self._states[indexes] = states
-        self._actions[indexes] = actions
-        self._rewards[indexes] = rewards
-        self._terminals[indexes] = terminals
-        self._next_states[indexes] = next_states
-
     def put(self, transition_batch: TransitionBatch) -> None:
         batch_size = len(transition_batch.states)
         if SHAPE_CHECK_FLAG:
@@ -201,7 +164,6 @@ class ReplayMemory(AbsReplayMemory, metaclass=ABCMeta):
         assert all([0 <= idx < self._capacity for idx in indexes])
 
         return TransitionBatch(
-            policy_name='',
             states=self._states[indexes],
             actions=self._actions[indexes],
             rewards=self._rewards[indexes],
@@ -328,7 +290,6 @@ class MultiReplayMemory(AbsReplayMemory, metaclass=ABCMeta):
         assert all([0 <= idx < self._capacity for idx in indexes])
 
         return MultiTransitionBatch(
-            policy_names=[],
             states=self._states[indexes],
             actions=[action[indexes] for action in self._actions],
             rewards=[reward[indexes] for reward in self._rewards],

--- a/maro/rl_v3/training/trainer.py
+++ b/maro/rl_v3/training/trainer.py
@@ -9,7 +9,6 @@ from maro.rl_v3.learning import ExpElement
 from maro.rl_v3.policy import RLPolicy
 from maro.rl_v3.utils import CoroutineWrapper, RemoteObj
 
-from .replay_memory import MultiReplayMemory
 from .train_ops import AbsTrainOps
 from .utils import extract_trainer_name
 

--- a/maro/rl_v3/training/trainer.py
+++ b/maro/rl_v3/training/trainer.py
@@ -3,15 +3,15 @@
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from maro.rl_v3.learning import ExpElement
 from maro.rl_v3.policy import RLPolicy
-from maro.rl_v3.utils import CoroutineWrapper, MultiTransitionBatch, RemoteObj, TransitionBatch
+from maro.rl_v3.utils import CoroutineWrapper, RemoteObj
 
-from .replay_memory import MultiReplayMemory, ReplayMemory
+from .replay_memory import MultiReplayMemory
 from .train_ops import AbsTrainOps
 from .utils import extract_trainer_name
-from ..learning import ExpElement
 
 
 @dataclass
@@ -33,6 +33,7 @@ class AbsTrainer(object, metaclass=ABCMeta):
     def __init__(self, name: str, params: TrainerParams) -> None:
         self._name = name
         self._batch_size = params.batch_size
+        self._agent2policy = {}
 
         self._dispatcher_address: Optional[Tuple[str, int]] = None
         print(f"Creating trainer {self.__class__.__name__} {self._name}.")
@@ -70,7 +71,7 @@ class AbsTrainer(object, metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def record_new(self, exp_element: ExpElement) -> None:
+    def record(self, exp_element: ExpElement) -> None:
         raise NotImplementedError
 
     def set_dispatch_address(self, dispatcher_address: Tuple[str, int]) -> None:
@@ -104,6 +105,10 @@ class SingleTrainer(AbsTrainer, metaclass=ABCMeta):
 
         self._ops: Union[RemoteObj, CoroutineWrapper, None] = None  # To be created in `build()`
 
+        self._policy_creator: Dict[str, Callable[[str], RLPolicy]] = {}
+        self._policy_name: Optional[str] = None
+        self._get_policy_func: Optional[Callable] = None
+
     def register_policy_creator(
         self,
         global_policy_creator: Dict[str, Callable[[str], RLPolicy]]
@@ -121,18 +126,6 @@ class SingleTrainer(AbsTrainer, metaclass=ABCMeta):
         self._policy_name = list(self._policy_creator.keys())[0]
         self._get_policy_func = lambda: self._policy_creator[self._policy_name](self._policy_name)
 
-    def record(self, transition_batch: TransitionBatch) -> None:
-        """Record the experiences collected by external modules.
-
-        Args:
-            transition_batch (TransitionBatch): A TransitionBatch item that contains a batch of experiences.
-        """
-        assert isinstance(transition_batch, TransitionBatch)
-        self._replay_memory.put(transition_batch)
-
-    # def _get_batch(self, batch_size: int = None) -> TransitionBatch:
-    #     return self._replay_memory.sample(batch_size if batch_size is not None else self._batch_size)
-
     async def get_policy_state(self) -> Dict[str, object]:
         if not self._ops:
             raise ValueError("'build' needs to be called to create an ops instance first.")
@@ -145,7 +138,8 @@ class MultiTrainer(AbsTrainer, metaclass=ABCMeta):
     """
     def __init__(self, name: str, params: TrainerParams) -> None:
         super(MultiTrainer, self).__init__(name, params)
-        self._replay_memory: Optional[MultiReplayMemory] = None  # To be created in `build()`
+        self._policy_creator: Dict[str, Callable[[str], RLPolicy]] = {}
+        self._policy_names: List[str] = []
 
     def register_policy_creator(
         self,
@@ -156,17 +150,6 @@ class MultiTrainer(AbsTrainer, metaclass=ABCMeta):
             if extract_trainer_name(policy_name) == self.name
         }
         self._policy_names = sorted(list(self._policy_creator.keys()))
-
-    def record(self, transition_batch: MultiTransitionBatch) -> None:
-        """Record the experiences collected by external modules.
-
-        Args:
-            transition_batch (MultiTransitionBatch): A TransitionBatch item that contains a batch of experiences.
-        """
-        self._replay_memory.put(transition_batch)
-
-    def _get_batch(self, batch_size: int = None) -> MultiTransitionBatch:
-        return self._replay_memory.sample(batch_size if batch_size is not None else self._batch_size)
 
     @abstractmethod
     async def get_policy_state(self) -> Dict[str, object]:

--- a/maro/rl_v3/training/trainer_manager.py
+++ b/maro/rl_v3/training/trainer_manager.py
@@ -3,16 +3,12 @@
 
 import asyncio
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict
 from typing import Callable, Dict, List, Tuple
-
-import numpy as np
 
 from maro.rl_v3.learning import ExpElement
 from maro.rl_v3.policy import RLPolicy
-from maro.rl_v3.utils import MultiTransitionBatch, TransitionBatch
 
-from .trainer import AbsTrainer, MultiTrainer, SingleTrainer
+from .trainer import AbsTrainer
 from .utils import extract_trainer_name
 
 
@@ -108,7 +104,7 @@ class SimpleTrainerManager(AbsTrainerManager):
         for exp_element in experiences:  # Dispatch experiences to trainers tick by tick.
             self._dispatch_experience(exp_element)
 
-    def _dispatch_experience_new(self, exp_element: ExpElement) -> None:
+    def _dispatch_experience(self, exp_element: ExpElement) -> None:
         agent2trainer = {
             agent_name: extract_trainer_name(policy_name)
             for agent_name, policy_name in self._agent2policy.items()
@@ -117,92 +113,4 @@ class SimpleTrainerManager(AbsTrainerManager):
 
         for trainer_name, exp_elem in exp_dict.items():
             trainer = self._trainer_dict[trainer_name]
-            trainer.record_new(exp_elem)
-
-    def _dispatch_experience(self, exp_element: ExpElement) -> None:
-        state = exp_element.state
-        agent_state_dict = exp_element.agent_state_dict
-        action_dict = exp_element.action_dict
-        reward_dict = exp_element.reward_dict
-        terminal_dict = exp_element.terminal_dict
-        next_state = exp_element.next_state
-        next_agent_state_dict = exp_element.next_agent_state_dict
-
-        if next_state is None:
-            next_state = state
-
-        # Aggregate experiences by trainer
-        trainer_buffer = defaultdict(list)
-        for agent_name, agent_state in agent_state_dict.items():
-            policy_name = self._agent2policy[agent_name]
-            trainer_name = extract_trainer_name(policy_name)
-            action = action_dict[agent_name]
-            reward = reward_dict[agent_name]
-            trainer_buffer[trainer_name].append((
-                policy_name,
-                agent_state,
-                action,
-                reward,
-                next_agent_state_dict[agent_name] if agent_name in next_agent_state_dict else agent_state,
-                terminal_dict[agent_name]
-            ))
-
-        for trainer_name, exps in trainer_buffer.items():
-            if trainer_name not in self._trainer_dict:
-                continue
-            trainer = self._trainer_dict[trainer_name]
-            if isinstance(trainer, SingleTrainer):
-                assert len(exps) == 1, f"SingleTrainer must has exactly one policy. Currently, it has {len(exps)}."
-
-                policy_name: str = exps[0][0]
-                agent_state: np.ndarray = exps[0][1]
-                action: np.ndarray = exps[0][2]
-                reward: float = exps[0][3]
-                next_agent_state: np.ndarray = exps[0][4]
-                terminal: bool = exps[0][5]
-
-                batch = TransitionBatch(
-                    policy_name=policy_name,
-                    states=np.expand_dims(agent_state, axis=0),
-                    actions=np.expand_dims(action, axis=0),
-                    rewards=np.array([reward]),
-                    next_states=np.expand_dims(next_agent_state, axis=0),
-                    terminals=np.array([terminal])
-                )
-                trainer.record(transition_batch=batch)
-            elif isinstance(trainer, MultiTrainer):
-                policy_names: List[str] = []
-                actions: List[np.ndarray] = []
-                rewards: List[np.ndarray] = []
-                terminals: List[bool] = []
-                agent_states: List[np.ndarray] = []
-                next_agent_states: List[np.ndarray] = []
-
-                for exp in exps:
-                    policy_name: str = exp[0]
-                    agent_state: np.ndarray = exp[1]
-                    action: np.ndarray = exp[2]
-                    reward: float = exp[3]
-                    next_agent_state: np.ndarray = exp[4]
-                    terminal: bool = exp[5]
-
-                    policy_names.append(policy_name)
-                    actions.append(np.expand_dims(action, axis=0))
-                    rewards.append(np.array([reward]))
-                    terminals.append(terminal)
-                    agent_states.append(np.expand_dims(agent_state, axis=0))
-                    next_agent_states.append(np.expand_dims(next_agent_state, axis=0))
-
-                batch = MultiTransitionBatch(
-                    policy_names=policy_names,
-                    states=np.expand_dims(state, axis=0),
-                    actions=actions,
-                    rewards=rewards,
-                    next_states=np.expand_dims(next_state, axis=0),
-                    agent_states=agent_states,
-                    next_agent_states=next_agent_states,
-                    terminals=np.array(terminals)
-                )
-                trainer.record(batch)
-            else:
-                raise ValueError
+            trainer.record(exp_elem)

--- a/maro/rl_v3/utils/transition_batch.py
+++ b/maro/rl_v3/utils/transition_batch.py
@@ -8,7 +8,6 @@ from .objects import SHAPE_CHECK_FLAG
 
 @dataclass
 class TransitionBatch:
-    policy_name: str
     states: np.ndarray  # 2D
     actions: np.ndarray  # 2D
     rewards: np.ndarray  # 1D
@@ -26,7 +25,6 @@ class TransitionBatch:
 
 @dataclass
 class MultiTransitionBatch:
-    policy_names: List[str]
     states: np.ndarray  # 2D
     actions: List[np.ndarray]  # 2D
     rewards: List[np.ndarray]  # 1D

--- a/maro/rl_v3/workflow.py
+++ b/maro/rl_v3/workflow.py
@@ -2,8 +2,8 @@ import time
 from typing import Callable, Dict, List
 
 from maro.rl_v3.learning import AbsEnvSampler, ExpElement
-from maro.rl_v3.training.trainer_manager import AbsTrainerManager
 from maro.rl_v3.policy import RLPolicy
+from maro.rl_v3.training.trainer_manager import AbsTrainerManager
 
 
 def preprocess_policy_creator(

--- a/maro/rl_v3/workflow.py
+++ b/maro/rl_v3/workflow.py
@@ -58,12 +58,11 @@ def run_workflow_centralized_mode(
 
             print(f"Huoran log: collect_time = {collect_time}, policy_update_time = {policy_update_time}")
 
-            trainer_policy_states = trainer_manager.get_policy_states()
-            policy_states = {}
-            for v in trainer_policy_states.values():
-                policy_states.update(v)
-
             if running_mode == "decentralized":
+                trainer_policy_states = trainer_manager.get_policy_states()
+                policy_states = {}
+                for v in trainer_policy_states.values():
+                    policy_states.update(v)
                 env_sampler.set_policy_states(policy_states)
 
             # tracker = env_sampler.test(policy_state_dict=policy_states)

--- a/maro/rl_v3/workflows/main.py
+++ b/maro/rl_v3/workflows/main.py
@@ -8,7 +8,6 @@ from maro.rl_v3.learning.helpers import get_rollout_finish_msg
 from maro.rl_v3.training.trainer import BatchTrainer
 from maro.rl_v3.utils.common import from_env, get_eval_schedule, get_logger, get_module
 
-
 if __name__ == "__main__":
     # get user-defined scenario ingredients
     scenario = get_module(from_env("SCENARIO_PATH"))

--- a/maro/rl_v3/workflows/rollout.py
+++ b/maro/rl_v3/workflows/rollout.py
@@ -5,7 +5,6 @@ import os
 
 from maro.rl_v3.utils.common import from_env, get_logger, get_module
 
-
 if __name__ == "__main__":
     mode = from_env("MODE")
     env_sampler = getattr(get_module(from_env("SCENARIO_PATH")), "get_env_sampler")()

--- a/maro/rl_v3/workflows/test/main_test.py
+++ b/maro/rl_v3/workflows/test/main_test.py
@@ -7,7 +7,7 @@ from maro.rl_v3.training.trainer import BatchTrainer
 from maro.rl_v3.utils.distributed import RemoteObj, CoroutineAdapter
 from maro.rl_v3.workflows.test.ops_creator import ops_creator
 
-DISPATCHER_ADDRESS = None # ("127.0.0.1", 10000)
+DISPATCHER_ADDRESS = None  # ("127.0.0.1", 10000)
 
 
 class SingleTrainer:

--- a/maro/rl_v3/workflows/test/main_test.py
+++ b/maro/rl_v3/workflows/test/main_test.py
@@ -4,7 +4,7 @@ import time
 import torch
 
 from maro.rl_v3.training.trainer import BatchTrainer
-from maro.rl_v3.utils.distributed import RemoteObj, CoroutineAdapter
+from maro.rl_v3.utils.distributed import CoroutineAdapter, RemoteObj
 from maro.rl_v3.workflows.test.ops_creator import ops_creator
 
 DISPATCHER_ADDRESS = None  # ("127.0.0.1", 10000)

--- a/maro/rl_v3/workflows/test/ops_creator.py
+++ b/maro/rl_v3/workflows/test/ops_creator.py
@@ -1,8 +1,8 @@
 import time
 
 from torch import nn
-from torch.optim import Adam
 from torch.nn import NLLLoss
+from torch.optim import Adam
 
 SLEEP = 5
 
@@ -52,7 +52,7 @@ class TrainOps2:
 
 
 ops_creator = {
-    "single.ops": lambda name: TrainOps(name, Model(5, 2)), 
+    "single.ops": lambda name: TrainOps(name, Model(5, 2)),
     "multi.ops0": lambda name: TrainOps2(name, Model(7, 3)),
     "multi.ops1": lambda name: TrainOps2(name, Model(7, 3)),
     "multi.ops2": lambda name: TrainOps2(name, Model(7, 3))


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->
- Use `ExpElement` to transfer experiences (from env sampler => trainer manager)
- Simplify the recording logic in trainer manager. Instead, let the trainer to implement its own recording logic.
- For AC, maintain a replay memory for each agent. For DQN, merge all agents' experiences into one replay memory.
- For MADDPG, we currently requires that each policy relates to exactly one agent. 

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
