### PR TITLE
fix non-0 env start tick bug

### DIFF
--- a/examples/oncall_routing/greedy_with_time_window.py
+++ b/examples/oncall_routing/greedy_with_time_window.py
@@ -15,10 +15,11 @@ set_seeds(0)
 
 def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
     tick = running_env.tick
+    frame_index = running_env.business_engine.frame_index(running_env.tick)
     oncall_orders = event.oncall_orders
     route_meta_info_dict = event.route_meta_info_dict
     route_plan_dict = event.route_plan_dict
-    carriers_in_stop: List[bool] = (running_env.snapshot_list["carriers"][tick::"in_stop"] == 1).tolist()
+    carriers_in_stop: List[bool] = (running_env.snapshot_list["carriers"][frame_index::"in_stop"] == 1).tolist()
     est_duration_predictor = event.estimated_duration_predictor
 
     route_original_indexes = {}
@@ -140,7 +141,7 @@ def _get_actions(running_env: Env, event: OncallRoutingPayload) -> List[Action]:
 # Greedy: assign each on-call order to the closest stop on existing route.
 if __name__ == "__main__":
     env = Env(
-        scenario="oncall_routing", topology="example", start_tick=0, durations=1440,
+        scenario="oncall_routing", topology="example", start_tick=480, durations=960,
     )
 
     env.reset(keep_seed=True)

--- a/examples/oncall_routing/greedy_with_time_window.py
+++ b/examples/oncall_routing/greedy_with_time_window.py
@@ -151,4 +151,5 @@ if __name__ == "__main__":
         print(f"Processing {len(decision_event.oncall_orders)} oncall orders at tick {env.tick}.")
         metrics, decision_event, is_done = env.step(_get_actions(env, decision_event))
 
-    print(metrics)
+    for key, value in metrics.items():
+        print(f"{key}: {value}")

--- a/maro/simulator/scenarios/oncall_routing/business_engine.py
+++ b/maro/simulator/scenarios/oncall_routing/business_engine.py
@@ -243,13 +243,13 @@ class OncallRoutingBusinessEngine(AbsBusinessEngine):
     def _load_carrier_arrival_event(self) -> None:
         """Put the first arrival event of each route into the event buffer."""
         for route in self._routes:
-            self._route_last_arrival[route.name] = (self._head_quarter_coord, 0)
+            self._route_last_arrival[route.name] = (self._head_quarter_coord, self._start_tick)
             self._route_next_departure_dict[route.name] = None
 
             if len(route.remaining_plan) > 0:
                 carrier_arrival_payload = CarrierArrivalPayload(route.carrier_idx)
                 carrier_arrival_event = self._event_buffer.gen_cascade_event(
-                    tick=route.remaining_plan[0].actual_duration_from_last,
+                    tick=self._start_tick + route.remaining_plan[0].actual_duration_from_last,
                     event_type=Events.CARRIER_ARRIVAL,
                     payload=carrier_arrival_payload
                 )

--- a/maro/simulator/scenarios/oncall_routing/topologies/example/config.yml
+++ b/maro/simulator/scenarios/oncall_routing/topologies/example/config.yml
@@ -10,14 +10,14 @@ interrupt_cycle: 10
 order_transition:
   buffer_before_open_time: 30 # Unit: tick; how long it could be ready in advance
   buffer_after_open_time: 30  # Unit: tick; actual termination tick would be min(close + buffer, rtb)
-  last_tick_for_order_processing: 960  # Unit: tick
+  last_tick_for_order_processing: 1440  # Unit: tick
   processing_time: 1  # Unit: tick
   processing_proportion_to_quantity: False  # If True, processing_time * order quantity to process
 
 data_loader_config:
   data_loader_type: "history" # history, sample
   oncall_generator_type: "sample" # history, sample
-  start_tick: 0
+  start_tick: 480
   end_tick: 1439
   coordinate_keep_digit: 5
   duration_limit: 30


### PR DESCRIPTION
# Description

- Fix BE "start_tick" bug when start_tick > 0
- Update example env start_tick config
- Update topology data loader start_tick config 

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
