### PR TITLE
Better integrate Non RL policy

### DIFF
--- a/examples/cim/rl/env_sampler.py
+++ b/examples/cim/rl/env_sampler.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -17,9 +17,9 @@ from .config import (
 
 
 class CIMEnvSampler(AbsEnvSampler):
-    def _get_global_and_agent_state(
-        self, event: DecisionEvent, tick: int = None
-    ) -> Tuple[Optional[np.ndarray], Dict[Any, np.ndarray]]:
+    def _get_global_and_agent_state_impl(
+        self, event: DecisionEvent, tick: int = None,
+    ) -> Tuple[Union[None, np.ndarray, List[object]], Dict[Any, Union[np.ndarray, List[object]]]]:
         tick = self._env.tick
         vessel_snapshots, port_snapshots = self._env.snapshot_list["vessels"], self._env.snapshot_list["ports"]
         port_idx, vessel_idx = event.port_idx, event.vessel_idx
@@ -31,7 +31,9 @@ class CIMEnvSampler(AbsEnvSampler):
         ])
         return state, {port_idx: state}
 
-    def _translate_to_env_action(self, action_dict: Dict[Any, np.ndarray], event: DecisionEvent) -> Dict[Any, object]:
+    def _translate_to_env_action(
+        self, action_dict: Dict[Any, Union[np.ndarray, List[object]]], event: DecisionEvent,
+    ) -> Dict[Any, object]:
         action_space = action_shaping_conf["action_space"]
         finite_vsl_space = action_shaping_conf["finite_vessel_space"]
         has_early_discharge = action_shaping_conf["has_early_discharge"]

--- a/examples/supply_chain/rl/algorithms/rule_based.py
+++ b/examples/supply_chain/rl/algorithms/rule_based.py
@@ -1,127 +1,73 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import numpy as np
-import scipy.stats as st
+from abc import abstractmethod
+import math, random
+from typing import List, Optional
 
-from examples.supply_chain.rl.config import NUM_CONSUMER_ACTIONS
+from examples.supply_chain.rl.config import NUM_CONSUMER_ACTIONS, workflow_settings
 from maro.rl.policy import RuleBasedPolicy
 
-OR_STATE_OFFSET_INDEX = {
-    "is_facility": 0,
-    "sale_mean": 1,
-    "sale_std": 2,
-    "unit_storage_cost": 3,
-    "order_cost": 4,
-    "storage_capacity": 5,
-    "storage_levels": 6,
-    "consumer_in_transit_orders": 7,
-    "product_idx": 8,
-    "vlt": 9,
-    "service_level": 10,
-}
 
-
-def get_element(np_state: np.ndarray, key: str) -> np.ndarray:
-    offsets = np_state[0][-len(OR_STATE_OFFSET_INDEX):].astype(np.uint)
-    idx = OR_STATE_OFFSET_INDEX[key]
-    prev_idx = int(offsets[idx - 1]) if idx > 0 else 0
-    return np_state[:, prev_idx: offsets[idx]].squeeze()
+VLT_BUFFER_DAYS = workflow_settings["or_policy_vlt_buffer_days"]
 
 
 class DummyPolicy(RuleBasedPolicy):
-    def _rule(self, states: np.ndarray) -> list:
-        return [None] * states.shape[0]
+    def _rule(self, states: List[dict]) -> list:
+        return [None] * len(states)
 
 
 class ManufacturerBaselinePolicy(RuleBasedPolicy):
-    def _rule(self, states: np.ndarray) -> np.ndarray:
-        return 500 * np.ones(states.shape[0])
+    def _rule(self, states: List[dict]) -> List[int]:
+        return [500] * len(states)
 
 
-class ConsumerBaselinePolicy(RuleBasedPolicy):
-    def _rule(self, states: np.ndarray) -> np.ndarray:
-        batch_size = len(states)
-        res = np.random.randint(0, high=NUM_CONSUMER_ACTIONS, size=batch_size)
-        # consumer_source_inventory
-        available_inventory = get_element(states, "storage_levels")
-        inflight_orders = get_element(states, "consumer_in_transit_orders")
-        booked_table = available_inventory + inflight_orders
-        most_needed_product_id = np.expand_dims(get_element(states, "product_idx"), axis=1).astype(np.int)
-        booked = np.squeeze(np.take_along_axis(booked_table, most_needed_product_id, axis=1), axis=1)
-        sale_mean, sale_std = get_element(states, "sale_mean"), get_element(states, "sale_std")
-        service_level = get_element(states, "service_level")
-        vlt_buffer_days = 7
-        vlt = vlt_buffer_days + get_element(states, "vlt")
+class ConsumerBasePolicy(RuleBasedPolicy):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
 
-        non_facility_mask = ~(get_element(states, "is_facility").astype(np.bool))
-        capacity_mask = np.sum(booked_table, axis=1) <= get_element(states, "storage_capacity")
-        replenishment_mask = booked <= (vlt*sale_mean + np.sqrt(vlt) * sale_std * st.norm.ppf(service_level))
-        return res * (non_facility_mask & capacity_mask & replenishment_mask)
+        self._replenishment_threshold: Optional[float] = None
 
-# Q = \sqrt{2DK/h}
-# Q - optimal order quantity
-# D - annual demand quantity
-# K - fixed cost per order, setup cost (not per unit, typically cost of ordering and shipping and handling.
-#     This is not the cost of goods)
-# h - annual holding cost per unit,
-#     also known as carrying cost or storage cost (capital cost, warehouse space,
-#     refrigeration, insurance, etc. usually not related to the unit production cost)
+    def _take_action_mask(self, state: dict) -> bool:
+        booked_quantity = state["product_level"] + state["in_transition_quantity"]
+        storage_booked_quantity = state["storage_utilization"] + state["storage_in_transition_quantity"]
 
+        expected_vlt = VLT_BUFFER_DAYS + state["max_vlt"]
+        self._replenishment_threshold = (
+            expected_vlt * state["sale_mean"]
+            + math.sqrt(expected_vlt) * state["sale_std"] * state["service_level_ppf"]
+        )
 
-def _get_consumer_quantity(states: np.ndarray) -> np.ndarray:
-    order_cost = get_element(states, "order_cost")
-    holding_cost = get_element(states, "unit_storage_cost")
-    sale_gamma = get_element(states, "sale_mean")
-    consumer_quantity = np.sqrt(2 * sale_gamma * order_cost / holding_cost) / (sale_gamma + 1e-8)
-    return consumer_quantity.astype(np.int32)
+        capacity_mask = storage_booked_quantity <= state["storage_capacity"]
+        replenishment_mask = booked_quantity <= self._replenishment_threshold
+
+        return capacity_mask and replenishment_mask
+
+    @abstractmethod
+    def _get_action_quantity(self, state: dict) -> int:
+        raise NotImplementedError
+
+    def _rule(self, states: List[dict]) -> List[int]:
+        return [
+            self._take_action_mask(state) * self._get_action_quantity(state)
+            for state in states
+        ]
 
 
-class ConsumerEOQPolicy(RuleBasedPolicy):
-    def _rule(self, states: np.ndarray) -> np.ndarray:
-        # consumer_source_inventory
-        available_inventory = get_element(states, "storage_levels")
-        inflight_orders = get_element(states, "consumer_in_transit_orders")
-        booked_table = available_inventory + inflight_orders
-        most_needed_product_id = np.expand_dims(get_element(states, "product_idx"), axis=1).astype(np.int)
-        booked = np.squeeze(np.take_along_axis(booked_table, most_needed_product_id, axis=1), axis=1)
-
-        sale_mean, sale_std = get_element(states, "sale_mean"), get_element(states, "sale_std")
-        service_level = get_element(states, "service_level")
-        vlt_buffer_days = 7
-        vlt = vlt_buffer_days + get_element(states, "vlt")
-
-        non_facility_mask = ~(get_element(states, "is_facility").astype(np.bool))
-        # stop placing orders when the facilty runs out of capacity
-        capacity_mask = np.sum(booked_table, axis=1) <= get_element(states, "storage_capacity")
-        # whether replenishment point is reached
-        replenishment_mask = booked <= vlt*sale_mean + np.sqrt(vlt) * sale_std * st.norm.ppf(service_level)
-        return _get_consumer_quantity(states) * (non_facility_mask & capacity_mask & replenishment_mask)
+class ConsumerBaselinePolicy(ConsumerBasePolicy):
+    def _get_action_quantity(self, state: dict) -> int:
+        return random.randint(0, NUM_CONSUMER_ACTIONS - 1)
 
 
-# parameters: (r, R), calculate according to VLT, demand variances, and service level
-# replenish R - S units whenever the current stock is less than r
-# S denotes the number of units in stock
-class ConsumerMinMaxPolicy(RuleBasedPolicy):
-    def _rule(self, states: np.ndarray) -> np.ndarray:
-        # consumer_source_inventory
-        available_inventory = get_element(states, "storage_levels")
-        inflight_orders = get_element(states, "consumer_in_transit_orders")
-        booked_table = available_inventory + inflight_orders
+class ConsumerEOQPolicy(ConsumerBasePolicy):
+    def _get_action_quantity(self, state: dict) -> int:
+        quantity = math.sqrt(2 * state["sale_mean"] * state["order_cost"] / state["unit_storage_cost"])
+        quantity /= (state["sale_mean"] + 1e-8)
+        return int(quantity)
 
-        # stop placing orders if no risk of out of
-        most_needed_product_id = np.expand_dims(get_element(states, "product_idx"), axis=1).astype(np.int)
-        booked = np.squeeze(np.take_along_axis(booked_table, most_needed_product_id, axis=1), axis=1)
-        sale_mean, sale_std = get_element(states, "sale_mean"), get_element(states, "sale_std")
-        service_level = get_element(states, "service_level")
-        vlt_buffer_days = 10
-        vlt = vlt_buffer_days + get_element(states, "vlt")
-        r = vlt * sale_mean + np.sqrt(vlt) * sale_std * st.norm.ppf(service_level)
 
-        non_facility_mask = ~(get_element(states, "is_facility").astype(np.bool))
-        # stop placing orders when the facilty runs out of capacity
-        capacity_mask = np.sum(booked_table, axis=1) <= get_element(states, "storage_capacity")
-        sales_mask = booked <= r
-        R = 3 * r
-        consumer_action = (R - r) / (sale_mean + 1e-8)
-        return consumer_action.astype(np.int32) * (non_facility_mask & capacity_mask & sales_mask)
+class ConsumerMinMaxPolicy(ConsumerBasePolicy):
+    def _get_action_quantity(self, state: dict) -> int:
+        quantity = 3 * self._replenishment_threshold
+        quantity /= (state["sale_mean"] + 1e-8)
+        return int(quantity)

--- a/examples/supply_chain/rl/config.py
+++ b/examples/supply_chain/rl/config.py
@@ -13,6 +13,9 @@ IDX_DISTRIBUTION_PENDING_PRODUCT_QUANTITY, IDX_DISTRIBUTION_PENDING_ORDER_NUMBER
 seller_features = ("total_demand", "sold", "demand")
 IDX_SELLER_TOTAL_DEMAND, IDX_SELLER_SOLD, IDX_SELLER_DEMAND = 0, 1, 2
 
+consumer_features = ("order_cost", "latest_consumptions")
+IDX_CONSUMER_ORDER_COST, IDX_CONSUMER_LATEST_CONSUMPTIONS = 0, 1
+
 NUM_CONSUMER_ACTIONS = 10
 
 workflow_settings: dict = {
@@ -20,6 +23,7 @@ workflow_settings: dict = {
     "sale_hist_len": 4,
     "pending_order_len": 4,
     # "constraint_state_hist_len": 8,
+    "or_policy_vlt_buffer_days": 7,
     "reward_normalization": 1e7,
     "default_vehicle_type": "train",
 }

--- a/examples/supply_chain/rl/env_sampler.py
+++ b/examples/supply_chain/rl/env_sampler.py
@@ -11,20 +11,21 @@ from maro.rl.policy import AbsPolicy, RLPolicy
 from maro.rl.rollout import AbsAgentWrapper, AbsEnvSampler, CacheElement, SimpleAgentWrapper
 from maro.simulator import Env
 from maro.simulator.scenarios.supply_chain import (
-    ConsumerAction, ConsumerUnit, ManufactureAction, ManufactureUnit, ProductUnit
+    ConsumerAction, ConsumerUnit, ManufactureAction, ManufactureUnit
 )
 from maro.simulator.scenarios.supply_chain.actions import SupplyChainAction
-from maro.simulator.scenarios.supply_chain.business_engine import SupplyChainBusinessEngine
 from maro.simulator.scenarios.supply_chain.facilities import FacilityInfo
 from maro.simulator.scenarios.supply_chain.objects import SkuInfo, SkuMeta, SupplyChainEntity, VendorLeadingTimeInfo
 
 from examples.supply_chain.common.balance_calculator import BalanceSheetCalculator
 
-from .agent_state import serialize_state, SCAgentStates
+from .algorithms.rule_based import ConsumerBasePolicy
 from .config import (
-    distribution_features, env_conf, seller_features, workflow_settings,
+    consumer_features, distribution_features, env_conf, seller_features, workflow_settings,
 )
+from .or_agent_state import ScOrAgentStates
 from .policies import agent2policy, trainable_policies
+from .rl_agent_state import ScRlAgentStates
 
 
 def get_unit2product_unit(facility_info_dict: Dict[int, FacilityInfo]) -> Dict[int, int]:
@@ -122,8 +123,8 @@ class SCEnvSampler(AbsEnvSampler):
 
         # States of current tick, extracted from snapshot list.
         self._cur_distribution_states: Optional[np.ndarray] = None
-        self._cur_consumer_states: Optional[np.ndarray] = None
-        self._cur_seller_states: Optional[np.ndarray] = None
+        self._cur_seller_hist_states: Optional[np.ndarray] = None
+        self._cur_consumer_hist_states: Optional[np.ndarray] = None
 
         # Key: facility id; List Index: sku idx; Value: in transition product quantity.
         self._facility_in_transit_orders: Dict[int, List[int]] = {}
@@ -133,7 +134,7 @@ class SCEnvSampler(AbsEnvSampler):
         # Key: facility id
         self._storage_product_quantity: Dict[int, List[int]] = defaultdict(lambda: [0] * self._sku_number)
 
-        self._agent_states: SCAgentStates = SCAgentStates(
+        self._rl_agent_states: ScRlAgentStates = ScRlAgentStates(
             entity_dict=self._entity_dict,
             facility_info_dict=self._facility_info_dict,
             global_sku_id2idx=self._global_sku_id2idx,
@@ -143,75 +144,80 @@ class SCEnvSampler(AbsEnvSampler):
             settings=self._env_settings,
         )
 
+        self._storage_unit_cost_dict: Optional[Dict[int, Dict[int, int]]] = None
+        self._storage_capacity_dict: Optional[Dict[int, Dict[int, int]]] = None
+
+        self._or_agent_states: ScOrAgentStates = ScOrAgentStates(
+            entity_dict=self._entity_dict,
+            facility_info_dict=self._facility_info_dict,
+            global_sku_id2idx=self._global_sku_id2idx,
+        )
+
+    def _get_storage_unit_cost_and_capacity_info(self) -> Tuple[Dict[int, Dict[int, int]], Dict[int, Dict[int, int]]]:
+        # Key1: storage node index; Key2: product id/sku id; Value: storage unit cost.
+        storage_unit_cost_dict: Dict[int, Dict[int, int]] = defaultdict(dict)
+        # Key1: storage node index; Key2: product id/sku id; Value: sub storage capacity.
+        storage_capacity_dict: Dict[int, Dict[int, int]] = defaultdict(dict)
+
+        storage_snapshots = self._learn_env.snapshot_list["storage"]
+        for node_index in range(len(storage_snapshots)):
+            storage_unit_cost_list = storage_snapshots[0:node_index:"unit_storage_cost"].flatten()
+            storage_capacity_list = storage_snapshots[0:node_index:"capacity"].flatten().astype(int)
+            product_storage_index_list = storage_snapshots[0:node_index:"product_storage_index"].flatten().astype(int)
+            product_id_list = storage_snapshots[0:node_index:"product_list"].flatten().astype(int)
+
+            for product_id, sub_storage_idx in zip(product_id_list, product_storage_index_list):
+                storage_unit_cost_dict[node_index][product_id] = storage_unit_cost_list[sub_storage_idx]
+                storage_capacity_dict[node_index][product_id] = storage_capacity_list[sub_storage_idx]
+
+        return storage_unit_cost_dict, storage_capacity_dict
+
     def _get_reward_for_entity(self, entity: SupplyChainEntity, bwt: Tuple[float, float]) -> float:
         if entity.class_type == ConsumerUnit:
             return np.float32(bwt[1]) / np.float32(self._env_settings["reward_normalization"])
         else:
             return .0
 
-    def get_or_policy_state(self, entity: SupplyChainEntity) -> np.ndarray:
-        # TODO: check the correctness of the implementation
-        if entity.skus is None:
-            return np.array([1])
+    def get_or_policy_state(self, entity: SupplyChainEntity) -> dict:
+        if self._storage_unit_cost_dict is None:
+            self._storage_unit_cost_dict, self._storage_capacity_dict = self._get_storage_unit_cost_and_capacity_info()
 
-        np_state, offsets = [0], [1]
+        state = self._or_agent_states._update_entity_state(
+            entity_id=entity.id,
+            storage_unit_cost_dict=self._storage_unit_cost_dict,
+            storage_capacity_dict=self._storage_capacity_dict,
+            product_metrics=self._cur_metrics["products"].get(self._unit2product_unit[entity.id], None),
+            cur_consumer_hist_states=self._cur_consumer_hist_states,
+            product_levels=self._storage_product_quantity[entity.facility_id],
+            in_transit_order_quantity=self._facility_in_transit_orders[entity.facility_id],
+        )
 
-        def extend_state(value: list) -> None:
-            np_state.extend(value)
-            offsets.append(len(np_state))
+        return state
 
-        product_unit_id = entity.id if entity.class_type == ProductUnit else entity.parent_id
-
-        product_index = self._balance_calculator.product_id2idx.get(product_unit_id, None)
-        unit_storage_cost = self._balance_calculator.products[product_index][4] if product_index is not None else 0
-
-        product_metrics = self._cur_metrics["products"].get(product_unit_id, None)
-        extend_state([product_metrics["sale_mean"] if product_metrics else 0])
-        extend_state([product_metrics["sale_std"] if product_metrics else 0])
-
-        extend_state([unit_storage_cost])
-        extend_state([1])
-        facility_info = self._facility_info_dict[entity.facility_id]
-        product_info = facility_info.products_info[entity.skus.id]
-        if product_info.consumer_info is not None:
-            idx = product_info.consumer_info.node_index
-            np_state[-1] = self._learn_env.snapshot_list["consumer"][
-                self._learn_env.tick:idx:"order_cost"
-            ].flatten()[0]
-
-        be = self._env.business_engine
-        assert isinstance(be, SupplyChainBusinessEngine)
-        extend_state([facility_info.storage_info.config[0].capacity])
-        extend_state(self._storage_product_quantity[entity.facility_id])
-        extend_state(self._facility_in_transit_orders[entity.facility_id])
-        extend_state([self._product_id2idx[entity.facility_id][entity.skus.id] + 1])  # TODO: check +1 or not
-        extend_state([be.world.get_facility_by_id(entity.facility_id).get_max_vlt(entity.skus.id)])
-        extend_state([entity.skus.service_level])
-        return np.array(np_state + offsets)
-
-    def get_rl_policy_state(self, entity_id: int, entity: SupplyChainEntity) -> np.ndarray:
-        state = self._agent_states.update_entity_state(
+    def get_rl_policy_state(self, entity_id: int) -> np.ndarray:
+        np_state = self._rl_agent_states.update_entity_state(
             entity_id=entity_id,
             tick=self._learn_env.tick,
             cur_metrics=self._cur_metrics,
             cur_distribution_states=self._cur_distribution_states,
-            cur_seller_states=self._cur_seller_states,
-            cur_consumer_states=self._cur_consumer_states,
+            cur_seller_hist_states=self._cur_seller_hist_states,
+            cur_consumer_hist_states=self._cur_consumer_hist_states,
             accumulated_balance=self._balance_calculator.accumulated_balance_sheet[entity_id],
             storage_product_quantity=self._storage_product_quantity,
             facility_product_utilization=self._facility_product_utilization,
             facility_in_transit_orders=self._facility_in_transit_orders,
         )
-        np_state = serialize_state(state)
         return np_state
 
-    def _get_entity_state(self, entity_id: int) -> np.ndarray:
+    def _get_entity_state(self, entity_id: int) -> Union[np.ndarray, dict, None]:
         entity = self._entity_dict[entity_id]
 
         if isinstance(self._policy_dict[self._agent2policy[entity_id]], RLPolicy):
-            return self.get_rl_policy_state(entity_id, entity)
-        else:
+            return self.get_rl_policy_state(entity_id)
+        elif isinstance(self._policy_dict[self._agent2policy[entity_id]], ConsumerBasePolicy):
             return self.get_or_policy_state(entity)
+        else:
+            return None
 
     def _get_global_and_agent_state_impl(
         self, event: CascadeEvent, tick: int = None,
@@ -235,15 +241,15 @@ class SCEnvSampler(AbsEnvSampler):
 
         # Get consumer features of specific ticks from snapshot list.
         consumption_hist_ticks = [tick - i for i in range(self._env_settings['consumption_hist_len'] - 1, -1, -1)]
-        self._cur_consumer_states = self._learn_env.snapshot_list["consumer"][
-            consumption_hist_ticks::"latest_consumptions"
-        ].flatten().reshape(-1, len(self._learn_env.snapshot_list["consumer"]))
+        self._cur_consumer_hist_states = self._learn_env.snapshot_list["consumer"][
+            consumption_hist_ticks::consumer_features
+        ].reshape(self._env_settings['consumption_hist_len'], -1, len(consumer_features))
 
         # Get seller features of specific ticks from snapshot list.
         sale_hist_ticks = [tick - i for i in range(self._env_settings['sale_hist_len'] - 1, -1, -1)]
-        self._cur_seller_states = self._learn_env.snapshot_list["seller"][
+        self._cur_seller_hist_states = self._learn_env.snapshot_list["seller"][
             sale_hist_ticks::seller_features
-        ].astype(np.int)
+        ].reshape(self._env_settings['sale_hist_len'], -1, len(seller_features)).astype(np.int)
 
         # 1. Update storage product quantity info.
         # 2. Update facility product utilization info.

--- a/examples/supply_chain/rl/env_sampler.py
+++ b/examples/supply_chain/rl/env_sampler.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 
@@ -213,7 +213,9 @@ class SCEnvSampler(AbsEnvSampler):
         else:
             return self.get_or_policy_state(entity)
 
-    def _get_global_and_agent_state(self, event: CascadeEvent, tick: int = None) -> tuple:
+    def _get_global_and_agent_state_impl(
+        self, event: CascadeEvent, tick: int = None,
+    ) -> Tuple[Union[None, np.ndarray, List[object]], Dict[Any, Union[np.ndarray, List[object]]]]:
         """Update the status variables first, then call the state shaper for each agent."""
         if tick is None:
             tick = self._learn_env.tick
@@ -281,7 +283,9 @@ class SCEnvSampler(AbsEnvSampler):
             if unit_id in self._agent2policy
         }
 
-    def _translate_to_env_action(self, action_dict: Dict[Any, np.ndarray], event: object) -> Dict[Any, object]:
+    def _translate_to_env_action(
+        self, action_dict: Dict[Any, Union[np.ndarray, List[object]]], event: object,
+    ) -> Dict[Any, object]:
         env_action_dict: Dict[int, SupplyChainAction] = {}
 
         for agent_id, action in action_dict.items():

--- a/examples/supply_chain/rl/or_agent_state.py
+++ b/examples/supply_chain/rl/or_agent_state.py
@@ -1,0 +1,89 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import scipy.stats as st
+from examples.supply_chain.rl.config import IDX_CONSUMER_ORDER_COST
+
+from maro.simulator.scenarios.supply_chain.facilities import FacilityBase, FacilityInfo
+from maro.simulator.scenarios.supply_chain.objects import SupplyChainEntity
+
+
+class ScOrAgentStates:
+    def __init__(
+        self,
+        entity_dict: Dict[int, SupplyChainEntity],
+        facility_info_dict: Dict[int, FacilityInfo],
+        global_sku_id2idx: Dict[int, int],
+    ) -> None:
+        self._entity_dict: Dict[int, SupplyChainEntity] = entity_dict
+        self._facility_info_dict: Dict[int, FacilityInfo] = facility_info_dict
+        self._global_sku_id2idx: Dict[int, int] = global_sku_id2idx
+
+        self._storage_unit_cost_dict: Optional[Dict[int, Dict[int, int]]] = None
+        self._storage_capacity_dict: Optional[Dict[int, Dict[int, int]]] = None
+
+        self._templates: Dict[int, dict] = {}
+
+    def _init_entity_state(self, entity: SupplyChainEntity) -> dict:
+        facility_info = self._facility_info_dict[entity.facility_id]
+        storage_index = facility_info.storage_info.node_index
+
+        state: dict = {
+            "sale_mean": 0,
+            "sale_std": 0,
+            "unit_storage_cost": self._storage_unit_cost_dict[storage_index][entity.skus.id],
+            "order_cost": 1,
+            "storage_capacity": self._storage_capacity_dict[storage_index][entity.skus.id],
+            "storage_utilization": 0,
+            "storage_in_transition_quantity": 0,
+            "product_level": 0,
+            "in_transition_quantity": 0,
+            "max_vlt": facility_info.products_info[entity.skus.id].max_vlt,
+            "service_level_ppf": st.norm.ppf(entity.skus.service_level),
+        }
+
+        return state
+
+    def _update_entity_state(
+        self,
+        entity_id: int,
+        storage_unit_cost_dict: Optional[Dict[int, Dict[int, int]]],
+        storage_capacity_dict: Optional[Dict[int, Dict[int, int]]],
+        product_metrics: Optional[dict],
+        cur_consumer_hist_states: np.ndarray,
+        product_levels: List[int],
+        in_transit_order_quantity: List[int],
+    ) -> dict:
+        entity: SupplyChainEntity = self._entity_dict[entity_id]
+
+        if issubclass(entity.class_type, FacilityBase):
+            return {}
+
+        if entity_id not in self._templates:
+            if self._storage_unit_cost_dict is None:
+                self._storage_unit_cost_dict = storage_unit_cost_dict
+                self._storage_capacity_dict = storage_capacity_dict
+
+            self._templates[entity_id] = self._init_entity_state(entity)
+
+        state: dict = self._templates[entity_id]
+
+        facility_info: FacilityInfo = self._facility_info_dict[entity.facility_id]
+        consumer_info = facility_info.products_info[entity.skus.id].consumer_info
+
+        state["sale_mean"] = product_metrics["sale_mean"]
+        state["sale_std"] = product_metrics["sale_std"]
+
+        state["order_cost"] = cur_consumer_hist_states[-1, consumer_info.node_index, IDX_CONSUMER_ORDER_COST]
+
+        state["storage_utilization"] = sum(product_levels)
+        state["storage_in_transition_quantity"] = sum(in_transit_order_quantity)
+
+        state["product_level"] = product_levels[self._global_sku_id2idx[entity.skus.id]]
+        state["in_transition_quantity"] = in_transit_order_quantity[self._global_sku_id2idx[entity.skus.id]]
+
+        return state

--- a/maro/rl/policy/abs_policy.py
+++ b/maro/rl/policy/abs_policy.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Iterable, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import torch
@@ -27,14 +27,14 @@ class AbsPolicy(object, metaclass=ABCMeta):
         self._trainable = trainable
 
     @abstractmethod
-    def get_actions(self, states: object) -> Iterable:
+    def get_actions(self, states: object) -> object:
         """Get actions according to states.
 
         Args:
             states (object): States.
 
         Returns:
-            actions (Iterable): Actions.
+            actions (object): Actions.
         """
         raise NotImplementedError
 
@@ -107,11 +107,11 @@ class RuleBasedPolicy(AbsPolicy, metaclass=ABCMeta):
     def __init__(self, name: str) -> None:
         super(RuleBasedPolicy, self).__init__(name=name, trainable=False)
 
-    def get_actions(self, states: object) -> object:
+    def get_actions(self, states: List[object]) -> List[object]:
         return self._rule(states)
 
     @abstractmethod
-    def _rule(self, states: object) -> object:
+    def _rule(self, states: List[object]) -> List[object]:
         raise NotImplementedError
 
     def explore(self) -> None:

--- a/maro/rl/rollout/env_sampler.py
+++ b/maro/rl/rollout/env_sampler.py
@@ -283,8 +283,6 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
             policy = self._policy_dict[policy_name]
             if isinstance(policy, RLPolicy) and not isinstance(state, np.ndarray):
                 raise ValueError(f"Agent {agent_name} uses a RLPolicy but its state is not a np.ndarray.")
-            if not isinstance(policy, RLPolicy) and not isinstance(state, list):
-                raise ValueError(f"Agent {agent_name} uses a non RLPolicy but its state is not a list.")
         return global_state, agent_state_dict
 
     @abstractmethod

--- a/maro/rl/rollout/env_sampler.py
+++ b/maro/rl/rollout/env_sampler.py
@@ -8,7 +8,7 @@ import os
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import Any, Callable, Deque, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Deque, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
@@ -45,15 +45,18 @@ class AbsAgentWrapper(object, metaclass=ABCMeta):
             if isinstance(policy, RLPolicy):
                 policy.set_state(policy_state)
 
-    def choose_actions(self, state_by_agent: Dict[Any, np.ndarray]) -> Dict[Any, np.ndarray]:
+    def choose_actions(
+        self, state_by_agent: Dict[Any, Union[np.ndarray, List[object]]]
+    ) -> Dict[Any, Union[np.ndarray, List[object]]]:
         """Choose action according to the given (observable) states of all agents.
 
         Args:
-            state_by_agent (Dict[Any, np.ndarray]): Dictionary containing each agent's state vector.
-                The keys are agent names.
+            state_by_agent (Dict[Any, Union[np.ndarray, List[object]]]): Dictionary containing each agent's states.
+                If the policy is a `RLPolicy`, its state is a Numpy array. Otherwise, its state is a list of objects.
 
         Returns:
-            actions (Dict[Any, np.ndarray]): Dict that contains the action for all agents.
+            actions (Dict[Any, Union[np.ndarray, List[object]]]): Dict that contains the action for all agents.
+                If the policy is a `RLPolicy`, its action is a Numpy array. Otherwise, its action is a list of objects.
         """
         self.switch_to_eval_mode()
         with torch.no_grad():
@@ -61,7 +64,9 @@ class AbsAgentWrapper(object, metaclass=ABCMeta):
         return ret
 
     @abstractmethod
-    def _choose_actions_impl(self, state_by_agent: Dict[Any, np.ndarray]) -> Dict[Any, np.ndarray]:
+    def _choose_actions_impl(
+        self, state_by_agent: Dict[Any, Union[np.ndarray, List[object]]],
+    ) -> Dict[Any, Union[np.ndarray, List[object]]]:
         """Implementation of `choose_actions`.
         """
         raise NotImplementedError
@@ -93,7 +98,9 @@ class SimpleAgentWrapper(AbsAgentWrapper):
     ) -> None:
         super(SimpleAgentWrapper, self).__init__(policy_dict=policy_dict, agent2policy=agent2policy)
 
-    def _choose_actions_impl(self, state_by_agent: Dict[Any, np.ndarray]) -> Dict[Any, np.ndarray]:
+    def _choose_actions_impl(
+        self, state_by_agent: Dict[Any, Union[np.ndarray, List[object]]],
+    ) -> Dict[Any, Union[np.ndarray, List[object]]]:
         # Aggregate states by policy
         states_by_policy = defaultdict(list)  # {str: list of np.ndarray}
         agents_by_policy = defaultdict(list)  # {str: list of str}
@@ -105,11 +112,14 @@ class SimpleAgentWrapper(AbsAgentWrapper):
         action_dict = {}
         for policy_name in agents_by_policy:
             policy = self._policy_dict[policy_name]
-            states = np.vstack(states_by_policy[policy_name])  # np.ndarray
-            action_dict.update(zip(
-                agents_by_policy[policy_name],  # list of str (agent name)
-                policy.get_actions(states),  # list of action
-            ))
+
+            if isinstance(policy, RLPolicy):
+                states = np.vstack(states_by_policy[policy_name])  # np.ndarray
+            else:
+                states = states_by_policy[policy_name]  # List[object]
+            actions = policy.get_actions(states)  # np.ndarray or List[object]
+            action_dict.update(zip(agents_by_policy[policy_name], actions))
+
         return action_dict
 
     def explore(self) -> None:
@@ -134,7 +144,7 @@ class CacheElement:
     state: np.ndarray
     agent_state_dict: Dict[Any, np.ndarray]
     action_dict: Dict[Any, np.ndarray]
-    env_action_dict: Dict[Any, object]
+    env_action_dict: Dict[Any, np.ndarray]
 
 
 @dataclass
@@ -237,6 +247,9 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
             agent_id for agent_id, policy_name in self._agent2policy.items() if policy_name in self._trainable_policies
         }
 
+        assert all([policy_name in self._rl_policy_dict for policy_name in self._trainable_policies]), \
+            "All trainable policies must be RL policies!"
+
         # Global state & agent state
         self._state: Optional[np.ndarray] = None
         self._agent_state_dict: Dict[Any, np.ndarray] = {}
@@ -250,10 +263,9 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
     def rl_policy_dict(self) -> Dict[str, RLPolicy]:
         return self._rl_policy_dict
 
-    @abstractmethod
     def _get_global_and_agent_state(
         self, event: object, tick: int = None,
-    ) -> Tuple[Optional[np.ndarray], Dict[Any, np.ndarray]]:
+    ) -> Tuple[Optional[object], Dict[Any, Union[np.ndarray, List[object]]]]:
         """Get the global and individual agents' states.
 
         Args:
@@ -261,17 +273,35 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
             tick (int, default=None): Current tick.
 
         Returns:
-            Global state (np.ndarray)
-            Dict of agent states (Dict[Any, np.ndarray])
+            Global state (Optional[object])
+            Dict of agent states (Dict[Any, Union[np.ndarray, List[object]]]). If the policy is a `RLPolicy`,
+                its state is a Numpy array. Otherwise, its state is a list of objects.
         """
+        global_state, agent_state_dict = self._get_global_and_agent_state_impl(event, tick)
+        for agent_name, state in agent_state_dict.items():
+            policy_name = self._agent2policy[agent_name]
+            policy = self._policy_dict[policy_name]
+            if isinstance(policy, RLPolicy) and not isinstance(state, np.ndarray):
+                raise ValueError(f"Agent {agent_name} uses a RLPolicy but its state is not a np.ndarray.")
+            if not isinstance(policy, RLPolicy) and not isinstance(state, list):
+                raise ValueError(f"Agent {agent_name} uses a non RLPolicy but its state is not a list.")
+        return global_state, agent_state_dict
+
+    @abstractmethod
+    def _get_global_and_agent_state_impl(
+        self, event: object, tick: int = None,
+    ) -> Tuple[Union[None, np.ndarray, List[object]], Dict[Any, Union[np.ndarray, List[object]]]]:
         raise NotImplementedError
 
     @abstractmethod
-    def _translate_to_env_action(self, action_dict: Dict[Any, np.ndarray], event: object) -> Dict[Any, object]:
+    def _translate_to_env_action(
+        self, action_dict: Dict[Any, Union[np.ndarray, List[object]]], event: object,
+    ) -> Dict[Any, object]:
         """Translate model-generated actions into an object that can be executed by the env.
 
         Args:
-            action_dict (Dict[Any, np.ndarray]): Action for all agents.
+            action_dict (Dict[Any, Union[np.ndarray, List[object]]]): Action for all agents. If the policy is a
+                `RLPolicy`, its (input) action is a Numpy array. Otherwise, its (input) action is a list of objects.
             event (object): Decision event.
 
         Returns:
@@ -336,11 +366,16 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
                     event=self._event,
                     state=self._state,
                     agent_state_dict={
-                        id_: state for id_, state in self._agent_state_dict.items() if id_ in self._trainable_agents
+                        id_: state
+                        for id_, state in self._agent_state_dict.items() if id_ in self._trainable_agents
                     },
-                    action_dict={id_: action for id_, action in action_dict.items() if id_ in self._trainable_agents},
+                    action_dict={
+                        id_: action
+                        for id_, action in action_dict.items() if id_ in self._trainable_agents
+                    },
                     env_action_dict={
-                        id_: env_action for id_, env_action in env_action_dict.items() if id_ in self._trainable_agents
+                        id_: env_action
+                        for id_, env_action in env_action_dict.items() if id_ in self._trainable_agents
                     },
                 )
             )

--- a/maro/simulator/scenarios/supply_chain/facilities/facility.py
+++ b/maro/simulator/scenarios/supply_chain/facilities/facility.py
@@ -177,7 +177,7 @@ class FacilityBase(ABC):
         ]
         return np.mean(src_prices) if len(src_prices) > 0 else self.skus[sku_id].price
 
-    def get_max_vlt(self, sku_id: int) -> float:
+    def get_max_vlt(self, sku_id: int) -> int:
         max_vlt: int = 0
         for vlt_info in self.upstream_vlt_infos[sku_id]:
             max_vlt = max(max_vlt, vlt_info.vlt)


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->

- Specify input/output data type for different kind of policies. For RL policies, we stipulate the input and output should both be `np.ndarray`. For rule-based policies, the input type is `List[object]`, and the return type could either be `np.ndarray` or `List[object]`.
- Since rule-based policies will not be trained by trainers, we do not need to store their experiences into `CacheElement` and `ExpElement`, so these two classes are not changed for now. However, if we need to train rule-based policies through external trainers in the future, we need to add dedicated processing logics for this demand.

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
