### PR TITLE
add leading time to ManufactureUnit

### DIFF
--- a/docs/source/key_components/data_model.rst
+++ b/docs/source/key_components/data_model.rst
@@ -1243,21 +1243,37 @@ Reward discount from action.
 manufacture
 +++++++++++
 
-manufacture_quantity
+start_manufacture_quantity
+**************************
+
+type: unsigned int
+slots: 1
+
+How many products start to produce at current tick, controlled by action.
+
+in_pipeline_quantity
 ********************
 
 type: unsigned int
 slots: 1
 
-How many products being produced at current tick, controlled by action.
+How many products in manufacture pipeline at current tick, will lead to manufacture cost.
 
-unit_product_cost
+finished_quantity
+*****************
+
+type: unsigned int
+slots: 1
+
+How many products are finished and exit manufacture pipeline at current tick.
+
+manufacture_cost
 *****************
 
 type: float
 slots: 1
 
-Cost to procedue a product.
+Manufacture cost spent to produce products in pipeline at current tick.
 
 seller
 ++++++

--- a/examples/supply_chain/common/balance_calculator.py
+++ b/examples/supply_chain/common/balance_calculator.py
@@ -219,10 +219,7 @@ class BalanceSheetCalculator:
         manufacture_ids = self._get_attributes("manufacture", "id", tick).astype(np.int)
 
         # loss = manufacture number * cost
-        manufacture_step_cost = -1 * (
-            self._get_attributes("manufacture", "manufacture_quantity", tick)
-            * self._get_attributes("manufacture", "unit_product_cost", tick)
-        )
+        manufacture_step_cost = -1 * self._get_attributes("manufacture", "manufacture_cost", tick)
 
         return manufacture_ids, manufacture_step_cost
 

--- a/examples/supply_chain/rl/env_sampler.py
+++ b/examples/supply_chain/rl/env_sampler.py
@@ -362,9 +362,7 @@ class SCEnvSampler(AbsEnvSampler):
 
             # Manufacture action
             elif issubclass(self._entity_dict[agent_id].class_type, ManufactureUnit):
-                sku = self._units_mapping[entity_id][3]
-                if sku.manufacture_rate:
-                    env_action = ManufactureAction(id=entity_id, production_rate=int(sku.manufacture_rate))
+                pass
 
             if env_action:
                 env_action_dict[agent_id] = env_action

--- a/examples/supply_chain/rl/policies.py
+++ b/examples/supply_chain/rl/policies.py
@@ -12,7 +12,7 @@ from maro.simulator.scenarios.supply_chain.objects import SupplyChainEntity
 
 from .rl_agent_state import STATE_DIM
 from .algorithms.ppo import get_policy, get_ppo
-from .algorithms.rule_based import DummyPolicy, ConsumerMinMaxPolicy
+from .algorithms.rule_based import ConsumerMinMaxPolicy
 from .config import NUM_CONSUMER_ACTIONS, env_conf
 
 
@@ -32,7 +32,7 @@ entity_dict: Dict[Any, SupplyChainEntity] = {
 
 def entity2policy(entity: SupplyChainEntity) -> Optional[str]:
     if issubclass(entity.class_type, ManufactureUnit):
-        return "manufacturer_policy"
+        return None
 
     elif issubclass(entity.class_type, ConsumerUnit):
         facility_name = facility_info_dict[entity.facility_id].name
@@ -53,7 +53,6 @@ def entity2policy(entity: SupplyChainEntity) -> Optional[str]:
 
 policy_creator = {
     "ppo.policy": partial(get_policy, STATE_DIM, NUM_CONSUMER_ACTIONS),
-    "manufacturer_policy": lambda name: DummyPolicy(name),
     "consumer_policy": lambda name: ConsumerMinMaxPolicy(name),
 }
 

--- a/examples/supply_chain/rl/sc_state_in_maro.md
+++ b/examples/supply_chain/rl/sc_state_in_maro.md
@@ -248,7 +248,7 @@ demand_hist = cur_seller_hist[:, 1].flatten()
 # 计算所需要属性
 consumer_features = ("id", "order_base_cost", "order_product_cost")
 seller_features = ("id", "sold", "demand", "backlog_ratio")
-manufacture_features = ("id", "manufacture_quantity", "unit_product_cost")
+manufacture_features = ("id", "manufacture_cost")
 
 # 对应的3种data model snapshot list
 consumer_ss = env.snapshot_list["consumer"]
@@ -290,8 +290,7 @@ seller_reward = seller_profit + seller_loss
 
 # manufacture部分
 # profit = 0
-# loss = manufacture_number * cost
-man_loss = -1 * man_states[:, 1] * man_states[:, 2]
+man_loss = -1 * man_states[:, 1]
 
 man_reward = man_loss
 

--- a/maro/simulator/scenarios/supply_chain/datamodels/manufacture.py
+++ b/maro/simulator/scenarios/supply_chain/datamodels/manufacture.py
@@ -10,23 +10,17 @@ from .extend import ExtendDataModel
 @node("manufacture")
 class ManufactureDataModel(ExtendDataModel):
     """Data model for manufacture unit."""
-    # Number per tick, different with original manufacturing cost, we just provide number, and cost
-    # user can determine how to calculate the cost.
-    manufacture_quantity = NodeAttribute(AttributeType.UInt)
+    start_manufacture_quantity = NodeAttribute(AttributeType.UInt)
+    in_pipeline_quantity = NodeAttribute(AttributeType.UInt)
+    finished_quantity = NodeAttribute(AttributeType.UInt)
 
-    unit_product_cost = NodeAttribute(AttributeType.Float)
+    manufacture_cost = NodeAttribute(AttributeType.Float)
 
     def __init__(self) -> None:
         super(ManufactureDataModel, self).__init__()
 
-        self._unit_product_cost = 0
-
-    def initialize(self, unit_product_cost) -> None:
-        self._unit_product_cost = unit_product_cost
-
+    def initialize(self) -> None:
         self.reset()
 
     def reset(self) -> None:
         super(ManufactureDataModel, self).reset()
-
-        self.unit_product_cost = self._unit_product_cost

--- a/maro/simulator/scenarios/supply_chain/objects.py
+++ b/maro/simulator/scenarios/supply_chain/objects.py
@@ -34,16 +34,30 @@ class SkuInfo:
     sub_storage_id: int = DEFAULT_SUB_STORAGE_ID  # TODO: decide whether it could be a default setting
     storage_upper_bound: Optional[int] = None  # TODO: Or split the storage directly?
 
-    # Manufacture config
-    has_manufacture: bool = False  # To indicate whether the ProductUnit has a ManufactureUnit or not
+    """
+    Manufacture configs:
+    - has_manufacture: To indicate whether the ProductUnit has a ManufactureUnit or not.
+    - unit_product_cost: Must set if has_manufacture.
+        . Per unit, per tick.
+        . The manufacture/production cost would be: unit_product_cost * manufacture_rate * manufacture_leading_time.
+    - max_manufacture_rate: Must set if has_manufacture.
+        . The manufacture capacity, or said the throughput of the manufacture pipeline.
+        . It is the upper bound of valid manufacture_rate could be set in the manufacture action.
+        . Note that it is the maximal product quantity we get at the end of a manufacture cycle (after a whole leading
+        time duration, not for each tick.)
+    - manufacture_leading_time: Must set if has_manufacture.
+        . How many ticks would it take to produce products.
+    """
+    has_manufacture: bool = False
     unit_product_cost: Optional[float] = None
-    manufacture_rate: Optional[int] = None  # The initial production rate.
-    # manufacture_leading_time: Optional[int] = None
+    max_manufacture_rate: Optional[int] = None
+    manufacture_leading_time: int = 0  # TODO: update default value after BE updated
 
     # Consumer config
     has_consumer: bool = False  # To indicate whether the ProductUnit has a ConsumerUnit or not
     # SKU specific one would be used if set, else the one for its facility would be used.
     unit_order_cost: Optional[float] = None
+
     # Seller config
     has_seller: bool = False  # To indicate whether the SellerUnit has a ConsumerUnit or not
     sale_gamma: Optional[int] = None

--- a/tests/supply_chain/test_supply_chain.py
+++ b/tests/supply_chain/test_supply_chain.py
@@ -66,9 +66,9 @@ class MyTestCase(unittest.TestCase):
         manufacture_nodes = env.snapshot_list["manufacture"]
         manufacture_number = len(manufacture_nodes)
         manufacture_features = (
-            "id", "facility_id", "manufacture_quantity", "product_id",
+            "id", "facility_id", "start_manufacture_quantity", "product_id",
         )
-        IDX_ID, IDX_FACILITY_ID, IDX_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID = 0, 1, 2, 3
+        IDX_ID, IDX_FACILITY_ID, IDX_START_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID = 0, 1, 2, 3
 
         # ############################### TICK: 0 ######################################
 
@@ -126,8 +126,8 @@ class MyTestCase(unittest.TestCase):
 
         states = manufacture_nodes[env.frame_index:sku3_data_model_index:manufacture_features].flatten().astype(np.int)
 
-        # Sku3 produce rate is 1 per tick, so manufacture_quantity should be 1.
-        self.assertEqual(1, states[IDX_MANUFACTURE_QUANTITY])
+        # Sku3 produce rate is 1 per tick, so start_manufacture_quantity should be 1.
+        self.assertEqual(1, states[IDX_START_MANUFACTURE_QUANTITY])
 
         remaining_spaces = storage_nodes[env.frame_index:sku3_storage_index:"remaining_space"].flatten().astype(np.int)
 
@@ -146,8 +146,8 @@ class MyTestCase(unittest.TestCase):
 
         states = manufacture_nodes[env.frame_index:sku3_data_model_index:manufacture_features].flatten().astype(np.int)
 
-        # so manufacture_quantity should be 0
-        self.assertEqual(0, states[IDX_MANUFACTURE_QUANTITY])
+        # so start_manufacture_quantity should be 0
+        self.assertEqual(0, states[IDX_START_MANUFACTURE_QUANTITY])
 
         product_dict = get_product_dict_from_storage(env, env.frame_index, sku3_storage_index)
 
@@ -161,8 +161,8 @@ class MyTestCase(unittest.TestCase):
 
         states = manufacture_nodes[env.frame_index:sku3_data_model_index:manufacture_features].flatten().astype(np.int)
 
-        # so manufacture_number should be 19 instead 20
-        self.assertEqual(19, states[IDX_MANUFACTURE_QUANTITY])
+        # so start_manufacture_number should be 19 instead 20
+        self.assertEqual(19, states[IDX_START_MANUFACTURE_QUANTITY])
 
         remaining_spaces = storage_nodes[env.frame_index:sku3_storage_index:"remaining_space"].flatten().astype(np.int)
 
@@ -187,9 +187,9 @@ class MyTestCase(unittest.TestCase):
         manufacture_nodes = env.snapshot_list["manufacture"]
         manufacture_number = len(manufacture_nodes)
         manufacture_features = (
-            "id", "facility_id", "manufacture_quantity", "product_id", "unit_product_cost",
+            "id", "facility_id", "start-manufacture_quantity", "product_id", "unit_product_cost",
         )
-        IDX_ID, IDX_FACILITY_ID, IDX_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID, IDX_UNIT_PRODUCT_COST = 0, 1, 2, 3, 4
+        IDX_ID, IDX_FACILITY_ID, IDX_START_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID, IDX_UNIT_PRODUCT_COST = 0, 1, 2, 3, 4
 
         # ############################### TICK: 0 ######################################
 
@@ -234,7 +234,7 @@ class MyTestCase(unittest.TestCase):
         ].flatten().astype(np.int)
 
         # manufacture_quantity should be 0
-        self.assertEqual(0, manufacture_states[IDX_MANUFACTURE_QUANTITY])
+        self.assertEqual(0, manufacture_states[IDX_START_MANUFACTURE_QUANTITY])
 
         # output product id should be same as configured.
         self.assertEqual(4, manufacture_states[IDX_PRODUCT_ID])
@@ -263,7 +263,7 @@ class MyTestCase(unittest.TestCase):
         ].flatten().astype(np.int)
 
         # manufacture_quantity should be 0
-        self.assertEqual(0, manufacture_states[IDX_MANUFACTURE_QUANTITY])
+        self.assertEqual(0, manufacture_states[IDX_START_MANUFACTURE_QUANTITY])
 
         # output product id should be same as configured.
         self.assertEqual(SKU4_ID, manufacture_states[IDX_PRODUCT_ID])
@@ -292,9 +292,9 @@ class MyTestCase(unittest.TestCase):
         manufacture_nodes = env.snapshot_list["manufacture"]
         manufacture_number = len(manufacture_nodes)
         manufacture_features = (
-            "id", "facility_id", "manufacture_quantity", "product_id", "unit_product_cost",
+            "id", "facility_id", "start_manufacture_quantity", "product_id", "unit_product_cost",
         )
-        IDX_ID, IDX_FACILITY_ID, IDX_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID, IDX_UNIT_PRODUCT_COST = 0, 1, 2, 3, 4
+        IDX_ID, IDX_FACILITY_ID, IDX_START_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID, IDX_UNIT_PRODUCT_COST = 0, 1, 2, 3, 4
 
         # ############################### TICK: 0 ######################################
 
@@ -333,7 +333,7 @@ class MyTestCase(unittest.TestCase):
         ].flatten().astype(np.int)
 
         # we can produce 4 sku1, as it will meet storage avg limitation per sku. 4 = 200//2 - 96
-        self.assertEqual(200 // 2 - 96, manufacture_states[IDX_MANUFACTURE_QUANTITY])
+        self.assertEqual(200 // 2 - 96, manufacture_states[IDX_START_MANUFACTURE_QUANTITY])
 
         # so storage remaining space should be 200 - ((96 + 4) + (100 - 4 * 2 sku3/sku1))
         remaining_spaces = storage_nodes[
@@ -363,7 +363,7 @@ class MyTestCase(unittest.TestCase):
         ].flatten().astype(np.int)
 
         # but manufacture number is 0
-        self.assertEqual(0, manufacture_states[IDX_MANUFACTURE_QUANTITY])
+        self.assertEqual(0, manufacture_states[IDX_START_MANUFACTURE_QUANTITY])
 
         # so storage remaining space should be 200 - ((96 + 4) + (100 - 4*2))
         remaining_spaces = storage_nodes[
@@ -390,9 +390,9 @@ class MyTestCase(unittest.TestCase):
         manufacture_nodes = env.snapshot_list["manufacture"]
         manufacture_number = len(manufacture_nodes)
         manufacture_features = (
-            "id", "facility_id", "manufacture_quantity", "product_id",
+            "id", "facility_id", "start_manufacture_quantity", "product_id",
         )
-        IDX_ID, IDX_FACILITY_ID, IDX_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID = 0, 1, 2, 3
+        IDX_ID, IDX_FACILITY_ID, IDX_START_MANUFACTURE_QUANTITY, IDX_PRODUCT_ID = 0, 1, 2, 3
 
         # ############################### TICK: 0 ######################################
 
@@ -451,7 +451,7 @@ class MyTestCase(unittest.TestCase):
         states = manufacture_nodes[env.frame_index:sku2_data_model_index:manufacture_features].flatten().astype(np.int)
 
         # Sku2 produce rate is 1 per tick, so manufacture_quantity should be 1.
-        self.assertEqual(1, states[IDX_MANUFACTURE_QUANTITY])
+        self.assertEqual(1, states[IDX_START_MANUFACTURE_QUANTITY])
 
         remaining_spaces = storage_nodes[env.frame_index:sku2_storage_index:"remaining_space"].flatten().astype(np.int)
 
@@ -473,7 +473,7 @@ class MyTestCase(unittest.TestCase):
         states = manufacture_nodes[env.frame_index:sku2_data_model_index:manufacture_features].flatten().astype(np.int)
 
         # so manufacture_quantity should be 0
-        self.assertEqual(0, states[IDX_MANUFACTURE_QUANTITY])
+        self.assertEqual(0, states[IDX_START_MANUFACTURE_QUANTITY])
 
         product_dict = get_product_dict_from_storage(env, env.frame_index, sku2_storage_index)
 


### PR DESCRIPTION
# Description

- add manufacture leading time
- add max manufacture rate limitation
- update manufacture data model
- let manufacture unit keep max_manufacture_rate as manufacture_rate if action not given

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.6
  - [ ] 3.7
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
