### PR TITLE
Compare PPO with spinning up

### DIFF
--- a/maro/rl/training/algorithms/base/ac_ppo_base.py
+++ b/maro/rl/training/algorithms/base/ac_ppo_base.py
@@ -291,6 +291,12 @@ class ACBasedTrainer(SingleAgentTrainer):
         assert isinstance(self._ops, ACBasedOps)
 
         batch = self._get_batch()
+        # for _ in range(self._params.grad_iters):
+        #     for minibatch in batch.make_minibatches(self._batch_size):
+        #         early_stop = self._ops.update_actor(minibatch)
+        #         if early_stop:
+        #             break
+        #         self._ops.update_critic(minibatch)
         for _ in range(self._params.grad_iters):
             self._ops.update_critic(batch)
 
@@ -304,8 +310,7 @@ class ACBasedTrainer(SingleAgentTrainer):
 
         batch = self._get_batch()
         for _ in range(self._params.grad_iters):
-            self._ops.update_critic_with_grad(await self._ops.get_critic_grad(batch))
-
-        for _ in range(self._params.grad_iters):
-            if self._ops.update_actor_with_grad(await self._ops.get_actor_grad(batch)):  # early stop
-                break
+            for minibatch in batch.make_minibatches(self._batch_size):
+                if self._ops.update_actor_with_grad(await self._ops.get_actor_grad(minibatch)):  # early stop
+                    break
+                self._ops.update_critic_with_grad(await self._ops.get_critic_grad(minibatch))

--- a/maro/rl/training/algorithms/base/ac_ppo_base.py
+++ b/maro/rl/training/algorithms/base/ac_ppo_base.py
@@ -202,6 +202,8 @@ class ACBasedOps(AbsTrainOps):
         # Preprocess advantages
         states = ndarray_to_tensor(batch.states, device=self._device)  # s
         actions = ndarray_to_tensor(batch.actions, device=self._device)  # a
+        terminals = ndarray_to_tensor(batch.terminals, device=self._device)
+        next_states = ndarray_to_tensor(batch.next_states, device=self._device)
         if self._is_discrete_action:
             actions = actions.long()
 
@@ -209,11 +211,26 @@ class ACBasedOps(AbsTrainOps):
             self._v_critic_net.eval()
             self._policy.eval()
             values = self._v_critic_net.v_values(states).detach().cpu().numpy()
-            values = np.concatenate([values, np.zeros(1)])
-            rewards = np.concatenate([batch.rewards, np.zeros(1)])
-            deltas = rewards[:-1] + self._reward_discount * values[1:] - values[:-1]  # r + gamma * v(s') - v(s)
-            batch.returns = discount_cumsum(rewards, self._reward_discount)[:-1]
-            batch.advantages = discount_cumsum(deltas, self._reward_discount * self._lam)
+            
+            batch.returns = np.zeros(batch.size, dtype=np.float32)
+            batch.advantages = np.zeros(batch.size, dtype=np.float32)
+            i = 0
+            while i < batch.size:
+                j = i
+                while j < batch.size - 1 and terminals[j] == False:
+                    j += 1
+                last_val = 0.0 if terminals[j] else self._v_critic_net.v_values(
+                    next_states[j].unsqueeze(dim=0)
+                ).detach().cpu().numpy().item()
+                
+                cur_values = np.append(values[i:j + 1], last_val)
+                cur_rewards = np.append(batch.rewards[i:j + 1], last_val)
+                # delta = r + gamma * v(s') - v(s)
+                cur_deltas = cur_rewards[:-1] + self._reward_discount * cur_values[1:] - cur_values[:-1]
+                batch.returns[i:j + 1] = discount_cumsum(cur_rewards, self._reward_discount)[:-1]
+                batch.advantages[i:j + 1] = discount_cumsum(cur_deltas, self._reward_discount * self._lam)
+                
+                i = j + 1
 
             if self._clip_ratio is not None:
                 batch.old_logps = self._policy.get_states_actions_logps(states, actions).detach().cpu().numpy()
@@ -291,26 +308,23 @@ class ACBasedTrainer(SingleAgentTrainer):
         assert isinstance(self._ops, ACBasedOps)
 
         batch = self._get_batch()
-        # for _ in range(self._params.grad_iters):
-        #     for minibatch in batch.make_minibatches(self._batch_size):
-        #         early_stop = self._ops.update_actor(minibatch)
-        #         if early_stop:
-        #             break
-        #         self._ops.update_critic(minibatch)
-        for _ in range(self._params.grad_iters):
-            self._ops.update_critic(batch)
-
+            
         for _ in range(self._params.grad_iters):
             early_stop = self._ops.update_actor(batch)
             if early_stop:
                 break
+        
+        for _ in range(self._params.grad_iters):
+            self._ops.update_critic(batch)
 
     async def train_step_as_task(self) -> None:
         assert isinstance(self._ops, RemoteOps)
 
         batch = self._get_batch()
+            
         for _ in range(self._params.grad_iters):
-            for minibatch in batch.make_minibatches(self._batch_size):
-                if self._ops.update_actor_with_grad(await self._ops.get_actor_grad(minibatch)):  # early stop
-                    break
-                self._ops.update_critic_with_grad(await self._ops.get_critic_grad(minibatch))
+            if self._ops.update_actor_with_grad(await self._ops.get_actor_grad(batch)):  # early stop
+                break
+        
+        for _ in range(self._params.grad_iters):
+            self._ops.update_critic_with_grad(await self._ops.get_critic_grad(batch))

--- a/maro/rl/training/replay_memory.py
+++ b/maro/rl/training/replay_memory.py
@@ -273,7 +273,7 @@ class ReplayMemory(AbsReplayMemory, metaclass=ABCMeta):
         Returns:
             batch (TransitionBatch): The sampled batch.
         """
-        indexes = self._get_sample_indexes(batch_size, self._get_forbid_last())
+        indexes = self._get_sample_indexes(batch_size, False)  # FIXME: check 'forbid_last' logic
         return self.sample_by_indexes(indexes)
 
     def sample_by_indexes(self, indexes: np.ndarray) -> TransitionBatch:

--- a/maro/rl/training/replay_memory.py
+++ b/maro/rl/training/replay_memory.py
@@ -47,15 +47,6 @@ class AbsIndexScheduler(object, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def get_last_index(self) -> int:
-        """Get the index of the latest element in the memory.
-
-        Returns:
-            index (int): The index of the latest element in the memory.
-        """
-        raise NotImplementedError
-
 
 class RandomIndexScheduler(AbsIndexScheduler):
     """Index scheduler that returns random indexes when sampling.
@@ -95,9 +86,6 @@ class RandomIndexScheduler(AbsIndexScheduler):
         assert batch_size is not None and batch_size > 0, f"Invalid batch size: {batch_size}"
         assert self._size > 0, "Cannot sample from an empty memory."
         return np.random.choice(self._size, size=batch_size, replace=True)
-
-    def get_last_index(self) -> int:
-        raise NotImplementedError
 
 
 class FIFOIndexScheduler(AbsIndexScheduler):
@@ -141,9 +129,6 @@ class FIFOIndexScheduler(AbsIndexScheduler):
         )
         self._head = self._tail
         return indexes
-
-    def get_last_index(self) -> int:
-        return (self._tail - 1) % self._capacity
 
 
 class AbsReplayMemory(object, metaclass=ABCMeta):
@@ -311,7 +296,6 @@ class RandomReplayMemory(ReplayMemory):
             RandomIndexScheduler(capacity, random_overwrite),
         )
         self._random_overwrite = random_overwrite
-        self._scheduler = RandomIndexScheduler(capacity, random_overwrite)
 
     @property
     def random_overwrite(self) -> bool:
@@ -475,7 +459,6 @@ class RandomMultiReplayMemory(MultiReplayMemory):
             agent_states_dims,
         )
         self._random_overwrite = random_overwrite
-        self._scheduler = RandomIndexScheduler(capacity, random_overwrite)
 
     @property
     def random_overwrite(self) -> bool:

--- a/maro/rl/utils/transition_batch.py
+++ b/maro/rl/utils/transition_batch.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Generator, List, Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -49,22 +49,6 @@ class TransitionBatch:
 
     def split(self, k: int) -> List[TransitionBatch]:
         return [self.make_kth_sub_batch(i, k) for i in range(k)]
-    
-    def make_minibatches(self, minibatch_size: int) -> Generator[TransitionBatch, None, None]:
-        i = 0
-        while i < self.size:
-            j = min(self.size, i + minibatch_size)
-            yield TransitionBatch(
-                states=self.states[i:j],
-                actions=self.actions[i:j],
-                rewards=self.rewards[i:j],
-                next_states=self.next_states[i:j],
-                terminals=self.terminals[i:j],
-                returns=self.returns[i:j] if self.returns is not None else None,
-                advantages=self.advantages[i:j] if self.advantages is not None else None,
-                old_logps=self.old_logps[i:j] if self.old_logps is not None else None,
-            )
-            i = j
 
 
 @dataclass

--- a/maro/rl/utils/transition_batch.py
+++ b/maro/rl/utils/transition_batch.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Generator, List, Optional
 
 import numpy as np
 
@@ -49,6 +49,22 @@ class TransitionBatch:
 
     def split(self, k: int) -> List[TransitionBatch]:
         return [self.make_kth_sub_batch(i, k) for i in range(k)]
+    
+    def make_minibatches(self, minibatch_size: int) -> Generator[TransitionBatch, None, None]:
+        i = 0
+        while i < self.size:
+            j = min(self.size, i + minibatch_size)
+            yield TransitionBatch(
+                states=self.states[i:j],
+                actions=self.actions[i:j],
+                rewards=self.rewards[i:j],
+                next_states=self.next_states[i:j],
+                terminals=self.terminals[i:j],
+                returns=self.returns[i:j] if self.returns is not None else None,
+                advantages=self.advantages[i:j] if self.advantages is not None else None,
+                old_logps=self.old_logps[i:j] if self.old_logps is not None else None,
+            )
+            i = j
 
 
 @dataclass

--- a/tests/rl/gym_wrapper/common.py
+++ b/tests/rl/gym_wrapper/common.py
@@ -10,7 +10,7 @@ from tests.rl.gym_wrapper.simulator.business_engine import GymBusinessEngine
 env_conf = {
     "topology": "Walker2d-v4",  # HalfCheetah-v4, Hopper-v4, Walker2d-v4, Swimmer-v4, Ant-v4
     "start_tick": 0,
-    "durations": 5000,
+    "durations": 1000,
     "options": {
         "random_seed": None,
     },

--- a/tests/rl/gym_wrapper/env_sampler.py
+++ b/tests/rl/gym_wrapper/env_sampler.py
@@ -84,6 +84,5 @@ class GymEnvSampler(AbsEnvSampler):
             "val/avg_reward": np.mean([r for _, r in self._eval_rewards]),
             "val/avg_n_steps": np.mean([n for n, _ in self._eval_rewards]),
         }
-        self._eval_rewards.clear()
         self.metrics.update(cur)
         self._eval_rewards.clear()

--- a/tests/rl/gym_wrapper/env_sampler.py
+++ b/tests/rl/gym_wrapper/env_sampler.py
@@ -75,6 +75,7 @@ class GymEnvSampler(AbsEnvSampler):
         self.metrics.update(cur)
         # clear validation metrics
         self.metrics = {k: v for k, v in self.metrics.items() if not k.startswith("val/")}
+        self._sample_rewards.clear()
 
     def post_evaluate(self, info_list: list, ep: int) -> None:
         cur = {
@@ -85,3 +86,4 @@ class GymEnvSampler(AbsEnvSampler):
         }
         self._eval_rewards.clear()
         self.metrics.update(cur)
+        self._eval_rewards.clear()

--- a/tests/rl/tasks/ac/__init__.py
+++ b/tests/rl/tasks/ac/__init__.py
@@ -26,11 +26,11 @@ from tests.rl.gym_wrapper.common import (
 from tests.rl.gym_wrapper.env_sampler import GymEnvSampler
 
 actor_net_conf = {
-    "hidden_dims": [64, 64],
+    "hidden_dims": [64, 32],
     "activation": torch.nn.Tanh,
 }
 critic_net_conf = {
-    "hidden_dims": [64, 64],
+    "hidden_dims": [64, 32],
     "activation": torch.nn.Tanh,
 }
 actor_learning_rate = 3e-4

--- a/tests/rl/tasks/ppo/__init__.py
+++ b/tests/rl/tasks/ppo/__init__.py
@@ -25,6 +25,8 @@ def get_ppo_trainer(name: str, state_dim: int) -> PPOTrainer:
     return PPOTrainer(
         name=name,
         reward_discount=0.99,
+        replay_memory_capacity=4000,
+        batch_size=4000,
         params=PPOParams(
             get_v_critic_net_func=lambda: MyVCriticNet(state_dim),
             grad_iters=80,

--- a/tests/rl/tasks/ppo/config.yml
+++ b/tests/rl/tasks/ppo/config.yml
@@ -6,10 +6,10 @@ scenario_path: "tests/rl/tasks/ppo"
 log_path: "tests/rl/log/ppo"
 main:
   num_episodes: 1000
-  num_steps: null
+  num_steps: 4000
   eval_schedule: 5
   num_eval_episodes: 10
-  min_n_sample: 5000
+  min_n_sample: 1
   logging:
     stdout: INFO
     file: DEBUG


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->

- Modify PPO algorithm
  - Refine `preprocess_batch` logic.
  - Switch the order of training critic/actor in a train step.
- Remove `forbid_last` in replay memory. It's meaningless after we refined PPO algorithm.
- Make PPO hyper-parameters exactly identical to spinning up's version.

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.7
  - [ ] 3.8
  - [ ] 3.9
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
