### PR TITLE
Episode truncation & early stopping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - id: isort
       args:
         - --settings-path=.github/linters/pyproject.toml
-#        - --check
+        - --check
 - repo: https://github.com/asottile/add-trailing-comma
   rev: v2.2.3
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - id: isort
       args:
         - --settings-path=.github/linters/pyproject.toml
-        - --check
+#        - --check
 - repo: https://github.com/asottile/add-trailing-comma
   rev: v2.2.3
   hooks:

--- a/examples/cim/rl/env_sampler.py
+++ b/examples/cim/rl/env_sampler.py
@@ -109,3 +109,6 @@ class CIMEnvSampler(AbsEnvSampler):
         print(f"average env summary (episode {ep}): {avg_metric}")
 
         self.metrics.update({"val/" + k: v for k, v in avg_metric.items()})
+
+    def monitor_metrics(self) -> float:
+        return -self.metrics["val/container_shortage"]

--- a/examples/rl/cim.yml
+++ b/examples/rl/cim.yml
@@ -15,6 +15,7 @@ main:
   num_episodes: 30  # Number of episodes to run. Each episode is one cycle of roll-out and training.
   num_steps: null
   eval_schedule: 5
+  early_stop_patience: 5
   logging:
     stdout: INFO
     file: DEBUG

--- a/maro/rl/model/abs_net.py
+++ b/maro/rl/model/abs_net.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import torch.nn
 from torch.optim import Optimizer
@@ -17,6 +17,8 @@ class AbsNet(torch.nn.Module, metaclass=ABCMeta):
 
     def __init__(self) -> None:
         super(AbsNet, self).__init__()
+        
+        self._device: Optional[torch.device] = None
 
     @property
     def optim(self) -> Optimizer:
@@ -119,3 +121,7 @@ class AbsNet(torch.nn.Module, metaclass=ABCMeta):
         """Unfreeze all parameters."""
         for p in self.parameters():
             p.requires_grad = True
+
+    def to_device(self, device: torch.device) -> None:
+        self._device = device
+        self.to(device)

--- a/maro/rl/model/abs_net.py
+++ b/maro/rl/model/abs_net.py
@@ -17,7 +17,7 @@ class AbsNet(torch.nn.Module, metaclass=ABCMeta):
 
     def __init__(self) -> None:
         super(AbsNet, self).__init__()
-        
+
         self._device: Optional[torch.device] = None
 
     @property

--- a/maro/rl/model/algorithm_nets/ac_based.py
+++ b/maro/rl/model/algorithm_nets/ac_based.py
@@ -54,3 +54,7 @@ class ContinuousACBasedNet(ContinuousPolicyNet, metaclass=ABCMeta):
     def _get_states_actions_probs_impl(self, states: torch.Tensor, actions: torch.Tensor) -> torch.Tensor:
         # Not used in Actor-Critic or PPO
         pass
+
+    def _get_random_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
+        # Not used in Actor-Critic or PPO
+        pass

--- a/maro/rl/model/algorithm_nets/ddpg.py
+++ b/maro/rl/model/algorithm_nets/ddpg.py
@@ -40,3 +40,7 @@ class ContinuousDDPGNet(ContinuousPolicyNet, metaclass=ABCMeta):
     def _get_states_actions_logps_impl(self, states: torch.Tensor, actions: torch.Tensor) -> torch.Tensor:
         # Not used in DDPG
         pass
+
+    def _get_random_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
+        # Not used in DDPG
+        pass

--- a/maro/rl/model/policy_net.py
+++ b/maro/rl/model/policy_net.py
@@ -221,3 +221,17 @@ class ContinuousPolicyNet(PolicyNet, metaclass=ABCMeta):
 
     def __init__(self, state_dim: int, action_dim: int) -> None:
         super(ContinuousPolicyNet, self).__init__(state_dim=state_dim, action_dim=action_dim)
+
+    def get_random_actions(self, states: torch.Tensor) -> torch.Tensor:
+        actions = self._get_random_actions_impl(states)
+
+        assert self._shape_check(
+            states=states,
+            actions=actions,
+        ), f"Actions shape check failed. Expecting: {(states.shape[0], self.action_dim)}, actual: {actions.shape}."
+
+        return actions
+
+    @abstractmethod
+    def _get_random_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError

--- a/maro/rl/policy/continuous_rl_policy.py
+++ b/maro/rl/policy/continuous_rl_policy.py
@@ -42,6 +42,8 @@ class ContinuousRLPolicy(RLPolicy):
             the bound for every dimension. If it is a float, it will be broadcast to all dimensions.
         policy_net (ContinuousPolicyNet): The core net of this policy.
         trainable (bool, default=True): Whether this policy is trainable.
+        warmup (int, default=0): Number of steps for uniform-random action selection, before running real policy.
+            Helps exploration.
     """
 
     def __init__(
@@ -50,6 +52,7 @@ class ContinuousRLPolicy(RLPolicy):
         action_range: Tuple[Union[float, List[float]], Union[float, List[float]]],
         policy_net: ContinuousPolicyNet,
         trainable: bool = True,
+        warmup: int = 0,
     ) -> None:
         assert isinstance(policy_net, ContinuousPolicyNet)
 
@@ -59,6 +62,7 @@ class ContinuousRLPolicy(RLPolicy):
             action_dim=policy_net.action_dim,
             trainable=trainable,
             is_discrete_action=False,
+            warmup=warmup,
         )
 
         self._lbounds, self._ubounds = _parse_action_range(self.action_dim, action_range)
@@ -138,4 +142,4 @@ class ContinuousRLPolicy(RLPolicy):
         self._policy_net.soft_update(other_policy.policy_net, tau)
 
     def _to_device_impl(self, device: torch.device) -> None:
-        self._policy_net.to(device)
+        self._policy_net.to_device(device)

--- a/maro/rl/policy/continuous_rl_policy.py
+++ b/maro/rl/policy/continuous_rl_policy.py
@@ -83,6 +83,9 @@ class ContinuousRLPolicy(RLPolicy):
     def _get_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
         return self._policy_net.get_actions(states, self._is_exploring)
 
+    def _get_random_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
+        return self._policy_net.get_random_actions(states)
+
     def _get_actions_with_probs_impl(self, states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         return self._policy_net.get_actions_with_probs(states, self._is_exploring)
 
@@ -117,10 +120,18 @@ class ContinuousRLPolicy(RLPolicy):
         self._policy_net.train()
 
     def get_state(self) -> dict:
-        return self._policy_net.get_state()
+        return {
+            "net": self._policy_net.get_state(),
+            "policy": {
+                "warmup": self._warmup,
+                "call_count": self._call_count,
+            },
+        }
 
     def set_state(self, policy_state: dict) -> None:
-        self._policy_net.set_state(policy_state)
+        self._policy_net.set_state(policy_state["net"])
+        self._warmup = policy_state["policy"]["warmup"]
+        self._call_count = policy_state["policy"]["call_count"]
 
     def soft_update(self, other_policy: RLPolicy, tau: float) -> None:
         assert isinstance(other_policy, ContinuousRLPolicy)

--- a/maro/rl/policy/discrete_rl_policy.py
+++ b/maro/rl/policy/discrete_rl_policy.py
@@ -91,7 +91,7 @@ class ValueBasedPolicy(DiscreteRLPolicy):
             state_dim=q_net.state_dim,
             action_num=q_net.action_num,
             trainable=trainable,
-            warmup=warmup
+            warmup=warmup,
         )
         self._q_net = q_net
 

--- a/maro/rl/rollout/env_sampler.py
+++ b/maro/rl/rollout/env_sampler.py
@@ -582,6 +582,7 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
                     terminal_dict={},
                     next_state=None,
                     next_agent_state_dict={},
+                    truncated=False,  # No truncation in evaluation
                 )
 
                 # Update env and get new states (global & agent)

--- a/maro/rl/rollout/env_sampler.py
+++ b/maro/rl/rollout/env_sampler.py
@@ -146,6 +146,7 @@ class ExpElement:
     terminal_dict: Dict[Any, bool]
     next_state: Optional[np.ndarray]
     next_agent_state_dict: Dict[Any, np.ndarray]
+    truncated: bool
 
     @property
     def agent_names(self) -> list:
@@ -171,6 +172,7 @@ class ExpElement:
                 }
                 if self.next_agent_state_dict is not None and agent_name in self.next_agent_state_dict
                 else {},
+                truncated=self.truncated,
             )
         return ret
 
@@ -194,6 +196,7 @@ class ExpElement:
                 terminal_dict={},
                 next_state=self.next_state,
                 next_agent_state_dict=None if self.next_agent_state_dict is None else {},
+                truncated=self.truncated,
             ),
         )
         for agent_name, trainer_name in agent2trainer.items():
@@ -225,6 +228,7 @@ class CacheElement(ExpElement):
             terminal_dict=self.terminal_dict,
             next_state=self.next_state,
             next_agent_state_dict=self.next_agent_state_dict,
+            truncated=self.truncated,
         )
 
 
@@ -240,6 +244,8 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
         agent_wrapper_cls (Type[AbsAgentWrapper], default=SimpleAgentWrapper): Specific AgentWrapper type.
         reward_eval_delay (int, default=None): Number of ticks required after a decision event to evaluate the reward
             for the action taken for that event. If it is None, calculate reward immediately after `step()`.
+        max_episode_length (int, default=None): Maximum number of steps in one episode during sampling.
+            When reach this limit, the environment will be truncated and reset.
     """
 
     def __init__(
@@ -251,6 +257,7 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
         trainable_policies: List[str] = None,
         agent_wrapper_cls: Type[AbsAgentWrapper] = SimpleAgentWrapper,
         reward_eval_delay: int = None,
+        max_episode_length: int = None,
     ) -> None:
         assert learn_env is not test_env, "Please use different envs for training and testing."
 
@@ -267,6 +274,8 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
         self._transition_cache: List[CacheElement] = []
         self._agent_last_index: Dict[Any, int] = {}  # Index of last occurrence of agent in self._transition_cache
         self._reward_eval_delay = reward_eval_delay
+        self._max_episode_length = max_episode_length
+        self._current_episode_length = 0
 
         self._info: dict = {}
         self.metrics: dict = {}
@@ -406,6 +415,7 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
 
     def _reset(self) -> None:
         self.env.reset()
+        self._current_episode_length = 0
         self._info.clear()
         self._transition_cache.clear()
         self._agent_last_index.clear()
@@ -413,6 +423,10 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
 
     def _select_trainable_agents(self, original_dict: dict) -> dict:
         return {k: v for k, v in original_dict.items() if k in self._trainable_agents}
+
+    @property
+    def truncated(self) -> bool:
+        return self._max_episode_length == self._current_episode_length
 
     def sample(
         self,
@@ -430,7 +444,7 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
         Returns:
             A dict that contains the collected experiences and additional information.
         """
-        steps_to_go = num_steps
+        steps_to_go = num_steps if num_steps is not None else float("inf")
         if policy_state is not None:  # Update policy state if necessary
             self.set_policy_state(policy_state)
         self._switch_env(self._learn_env)  # Init the env
@@ -439,17 +453,33 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
         if self._end_of_episode:
             self._reset()
 
+        # If num_steps is None, run until the end of episode or the episode is truncated
+        # If num_steps is not None, run until we collect required number of steps
         total_experiences = []
-        # If steps_to_go is None, run until the end of episode
-        # If steps_to_go is not None, run until we collect required number of steps
-        while (steps_to_go is None and not self._end_of_episode) or (steps_to_go is not None and steps_to_go > 0):
-            if self._end_of_episode:
+
+        while not any(
+            [
+                num_steps is None and (self._end_of_episode or self.truncated),
+                num_steps is not None and steps_to_go == 0,
+            ],
+        ):
+            if self._end_of_episode or self.truncated:
                 self._reset()
 
-            while not self._end_of_episode and (steps_to_go is None or steps_to_go > 0):
+            while not any(
+                [
+                    self._end_of_episode,
+                    self.truncated,
+                    steps_to_go == 0,
+                ],
+            ):
                 # Get agent actions and translate them to env actions
                 action_dict = self._agent_wrapper.choose_actions(self._agent_state_dict)
                 env_action_dict = self._translate_to_env_action(action_dict, self._event)
+
+                self._total_number_interactions += 1
+                self._current_episode_length += 1
+                steps_to_go -= 1
 
                 # Store experiences in the cache
                 cache_element = CacheElement(
@@ -459,24 +489,23 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
                     agent_state_dict=self._select_trainable_agents(self._agent_state_dict),
                     action_dict=self._select_trainable_agents(action_dict),
                     env_action_dict=self._select_trainable_agents(env_action_dict),
-                    # The following will be generated later
+                    # The following will be generated/updated later
                     reward_dict={},
                     terminal_dict={},
                     next_state=None,
                     next_agent_state_dict={},
+                    truncated=self.truncated,
                 )
 
                 # Update env and get new states (global & agent)
                 self._step(list(env_action_dict.values()))
-                self._total_number_interactions += 1
                 cache_element.next_state = self._state
 
                 if self._reward_eval_delay is None:
                     self._calc_reward(cache_element)
                     self._post_step(cache_element)
                 self._append_cache_element(cache_element)
-                if steps_to_go is not None:
-                    steps_to_go -= 1
+
             self._append_cache_element(None)
 
             tick_bound = self.env.tick - (0 if self._reward_eval_delay is None else self._reward_eval_delay)

--- a/maro/rl/rollout/env_sampler.py
+++ b/maro/rl/rollout/env_sampler.py
@@ -310,6 +310,10 @@ class AbsEnvSampler(object, metaclass=ABCMeta):
         assert self._env is not None
         return self._env
 
+    def monitor_metrics(self) -> float:
+        """Metrics watched by early stopping."""
+        return float(self._total_number_interactions)
+
     def _switch_env(self, env: Env) -> None:
         self._env = env
 

--- a/maro/rl/training/algorithms/base/ac_ppo_base.py
+++ b/maro/rl/training/algorithms/base/ac_ppo_base.py
@@ -203,6 +203,7 @@ class ACBasedOps(AbsTrainOps):
         states = ndarray_to_tensor(batch.states, device=self._device)  # s
         actions = ndarray_to_tensor(batch.actions, device=self._device)  # a
         terminals = ndarray_to_tensor(batch.terminals, device=self._device)
+        truncated = ndarray_to_tensor(batch.truncated, device=self._device)
         next_states = ndarray_to_tensor(batch.next_states, device=self._device)
         if self._is_discrete_action:
             actions = actions.long()
@@ -217,7 +218,7 @@ class ACBasedOps(AbsTrainOps):
             i = 0
             while i < batch.size:
                 j = i
-                while j < batch.size - 1 and not terminals[j]:
+                while j < batch.size - 1 and not (terminals[j] or truncated[j]):
                     j += 1
                 last_val = (
                     0.0

--- a/maro/rl/training/algorithms/maddpg.py
+++ b/maro/rl/training/algorithms/maddpg.py
@@ -378,6 +378,7 @@ class DiscreteMADDPGTrainer(MultiAgentTrainer):
             agent_states=agent_states,
             next_agent_states=next_agent_states,
             terminals=np.array(terminal_flags),
+            truncated=np.array([exp_element.truncated for exp_element in exp_elements]),
         )
         self._replay_memory.put(transition_batch)
 

--- a/maro/rl/training/trainer.py
+++ b/maro/rl/training/trainer.py
@@ -254,6 +254,7 @@ class SingleAgentTrainer(AbsTrainer, metaclass=ABCMeta):
                         exp_element.action_dict[agent_name],
                         exp_element.reward_dict[agent_name],
                         exp_element.terminal_dict[agent_name],
+                        exp_element.truncated,
                         exp_element.next_agent_state_dict.get(agent_name, exp_element.agent_state_dict[agent_name]),
                     ),
                 )
@@ -264,7 +265,8 @@ class SingleAgentTrainer(AbsTrainer, metaclass=ABCMeta):
                 actions=np.vstack([exp[1] for exp in exps]),
                 rewards=np.array([exp[2] for exp in exps]),
                 terminals=np.array([exp[3] for exp in exps]),
-                next_states=np.vstack([exp[4] for exp in exps]),
+                truncated=np.array([exp[4] for exp in exps]),
+                next_states=np.vstack([exp[5] for exp in exps]),
             )
             transition_batch = self._preprocess_batch(transition_batch)
             self.replay_memory.put(transition_batch)

--- a/maro/rl/workflows/callback.py
+++ b/maro/rl/workflows/callback.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from __future__ import annotations
+
 import copy
 import os
 import typing
@@ -69,7 +71,7 @@ class EarlyStopping(Callback):
             self.workflow.early_stop = True
             self.logger.info(
                 f"Validation metric has not been updated for {ep - self._best_ep} "
-                f"epochs (patience = {self._patience} epochs). Early stopping.",
+                f"epochs (patience = {self._patience} epochs). Early stop.",
             )
 
 

--- a/maro/rl/workflows/config/parser.py
+++ b/maro/rl/workflows/config/parser.py
@@ -293,7 +293,7 @@ class ConfigParser:
 
             main_proc_env["NUM_EVAL_EPISODES"] = str(self._config["main"].get("num_eval_episodes", 1))
         if "early_stop_patience" in self._config["main"]:
-            main_proc_env["EARLY_STOP_PATIENCE"] = self._config["main"]["early_stop_patience"]
+            main_proc_env["EARLY_STOP_PATIENCE"] = str(self._config["main"]["early_stop_patience"])
 
         load_path = self._config["training"].get("load_path", None)
         if load_path is not None:

--- a/maro/rl/workflows/config/parser.py
+++ b/maro/rl/workflows/config/parser.py
@@ -76,6 +76,11 @@ class ConfigParser:
                     f"positive ints",
                 )
 
+        early_stop_patience = self._config["main"].get("early_stop_patience", None)
+        if early_stop_patience is not None:
+            if not isinstance(early_stop_patience, int) or early_stop_patience <= 0:
+                raise ValueError(f"Invalid early stop patience: {early_stop_patience}. Should be a positive integer.")
+
         if "logging" in self._config["main"]:
             self._validate_logging_section("main", self._config["main"]["logging"])
 
@@ -287,13 +292,15 @@ class ConfigParser:
                 main_proc_env["EVAL_SCHEDULE"] = " ".join([str(val) for val in sorted(sch)])
 
             main_proc_env["NUM_EVAL_EPISODES"] = str(self._config["main"].get("num_eval_episodes", 1))
+        if "early_stop_patience" in self._config["main"]:
+            main_proc_env["EARLY_STOP_PATIENCE"] = self._config["main"]["early_stop_patience"]
 
         load_path = self._config["training"].get("load_path", None)
         if load_path is not None:
-            env["main"]["LOAD_PATH"] = path_mapping[load_path]
+            main_proc_env["LOAD_PATH"] = path_mapping[load_path]
         load_episode = self._config["training"].get("load_episode", None)
         if load_episode is not None:
-            env["main"]["LOAD_EPISODE"] = str(load_episode)
+            main_proc_env["LOAD_EPISODE"] = str(load_episode)
 
         if "checkpointing" in self._config["training"]:
             conf = self._config["training"]["checkpointing"]

--- a/maro/rl/workflows/config/template.yml
+++ b/maro/rl/workflows/config/template.yml
@@ -24,6 +24,7 @@ main:
   # A list indicates the episodes at the end of which policies are to be evaluated. Note that episode indexes are
   # 1-based.
   eval_schedule: 10
+  early_stop_patience: 10  # Number of epochs waiting for a better validation metrics. Could be `null`.
   num_eval_episodes: 10  # Number of Episodes to run in evaluation.
   # Minimum number of samples to start training in one epoch. The workflow will re-run experience collection
   # until we have at least `min_n_sample` of experiences.

--- a/maro/rl/workflows/main.py
+++ b/maro/rl/workflows/main.py
@@ -14,7 +14,7 @@ from maro.rl.training import TrainingManager
 from maro.rl.utils import get_torch_device
 from maro.rl.utils.common import float_or_none, get_env, int_or_none, list_or_none
 from maro.rl.utils.training import get_latest_ep
-from maro.rl.workflows.callback import CallbackManager, Checkpoint, MetricsRecorder, SupportedCallbackFunc
+from maro.rl.workflows.callback import CallbackManager, Checkpoint, MetricsRecorder
 from maro.utils import LoggerV2
 
 
@@ -113,105 +113,110 @@ def main(rl_component_bundle: RLComponentBundle, env_attr: WorkflowEnvAttributes
     if args.evaluate_only:
         evaluate_only_workflow(rl_component_bundle, env_attr)
     else:
-        training_workflow(rl_component_bundle, env_attr)
+        TrainingWorkflow().run(rl_component_bundle, env_attr)
 
 
-def training_workflow(rl_component_bundle: RLComponentBundle, env_attr: WorkflowEnvAttributes) -> None:
-    env_attr.logger.info("Start training workflow.")
+class TrainingWorkflow(object):
+    def run(self, rl_component_bundle: RLComponentBundle, env_attr: WorkflowEnvAttributes) -> None:
+        env_attr.logger.info("Start training workflow.")
 
-    env_sampler = _get_env_sampler(rl_component_bundle, env_attr)
+        env_sampler = _get_env_sampler(rl_component_bundle, env_attr)
 
-    # evaluation schedule
-    env_attr.logger.info(f"Policy will be evaluated at the end of episodes {env_attr.eval_schedule}")
-    eval_point_index = 0
+        # evaluation schedule
+        env_attr.logger.info(f"Policy will be evaluated at the end of episodes {env_attr.eval_schedule}")
+        eval_point_index = 0
 
-    training_manager = TrainingManager(
-        rl_component_bundle=rl_component_bundle,
-        explicit_assign_device=(env_attr.train_mode == "simple"),
-        proxy_address=None if env_attr.train_mode == "simple" else env_attr.proxy_address,
-        logger=env_attr.logger,
-    )
-
-    callbacks = []
-    if env_attr.checkpoint_path is not None:
-        callbacks.append(
-            Checkpoint(
-                path=env_attr.checkpoint_path,
-                interval=1 if env_attr.checkpoint_interval is None else env_attr.checkpoint_interval,
-            ),
+        training_manager = TrainingManager(
+            rl_component_bundle=rl_component_bundle,
+            explicit_assign_device=(env_attr.train_mode == "simple"),
+            proxy_address=None if env_attr.train_mode == "simple" else env_attr.proxy_address,
+            logger=env_attr.logger,
         )
-    callbacks.append(MetricsRecorder(path=env_attr.log_path))
-    cbm = CallbackManager(callbacks)
 
-    if env_attr.load_path:
-        assert isinstance(env_attr.load_path, str)
-
-        ep = env_attr.load_episode if env_attr.load_episode is not None else get_latest_ep(env_attr.load_path)
-        path = os.path.join(env_attr.load_path, str(ep))
-
-        loaded = env_sampler.load_policy_state(path)
-        env_attr.logger.info(f"Loaded policies {loaded} into env sampler from {path}")
-
-        loaded = training_manager.load(path)
-        env_attr.logger.info(f"Loaded trainers {loaded} from {path}")
-        start_ep = ep + 1
-    else:
-        start_ep = 1
-
-    # main loop
-    for ep in range(start_ep, env_attr.num_episodes + 1):
-        cbm.call(SupportedCallbackFunc.ON_EPISODE_START, env_sampler, training_manager, env_attr.logger, ep)
-
-        collect_time = training_time = 0.0
-        total_experiences: List[List[ExpElement]] = []
-        total_info_list: List[dict] = []
-        n_sample = 0
-        while n_sample < env_attr.min_n_sample:
-            tc0 = time.time()
-            result = env_sampler.sample(
-                policy_state=training_manager.get_policy_state() if not env_attr.is_single_thread else None,
-                num_steps=env_attr.num_steps,
+        callbacks = []
+        if env_attr.checkpoint_path is not None:
+            callbacks.append(
+                Checkpoint(
+                    path=env_attr.checkpoint_path,
+                    interval=1 if env_attr.checkpoint_interval is None else env_attr.checkpoint_interval,
+                ),
             )
-            experiences: List[List[ExpElement]] = result["experiences"]
-            info_list: List[dict] = result["info"]
+        callbacks.append(MetricsRecorder(path=env_attr.log_path))
+        cbm = CallbackManager(self, callbacks, env_sampler, training_manager, env_attr.logger)
 
-            n_sample += len(experiences[0])
-            total_experiences.extend(experiences)
-            total_info_list.extend(info_list)
+        if env_attr.load_path:
+            assert isinstance(env_attr.load_path, str)
 
-            collect_time += time.time() - tc0
+            ep = env_attr.load_episode if env_attr.load_episode is not None else get_latest_ep(env_attr.load_path)
+            path = os.path.join(env_attr.load_path, str(ep))
 
-        env_sampler.post_collect(total_info_list, ep)
+            loaded = env_sampler.load_policy_state(path)
+            env_attr.logger.info(f"Loaded policies {loaded} into env sampler from {path}")
 
-        tu0 = time.time()
-        env_attr.logger.info(f"Roll-out completed for episode {ep}. Training started...")
-        cbm.call(SupportedCallbackFunc.ON_TRAINING_START, env_sampler, training_manager, env_attr.logger, ep)
-        training_manager.record_experiences(total_experiences)
-        training_manager.train_step()
-        cbm.call(SupportedCallbackFunc.ON_TRAINING_END, env_sampler, training_manager, env_attr.logger, ep)
-        training_time += time.time() - tu0
+            loaded = training_manager.load(path)
+            env_attr.logger.info(f"Loaded trainers {loaded} from {path}")
+            start_ep = ep + 1
+        else:
+            start_ep = 1
 
-        # performance details
-        env_attr.logger.info(
-            f"ep {ep} - roll-out time: {collect_time:.2f} seconds, training time: {training_time:.2f} seconds",
-        )
-        if env_attr.eval_schedule and ep == env_attr.eval_schedule[eval_point_index]:
-            cbm.call(SupportedCallbackFunc.ON_VALIDATION_START, env_sampler, training_manager, env_attr.logger, ep)
+        # main loop
+        self.early_stop = False
+        for ep in range(start_ep, env_attr.num_episodes + 1):
+            if self.early_stop:  # Might be set in `cbm.on_validation_end()`
+                break
 
-            eval_point_index += 1
-            result = env_sampler.eval(
-                policy_state=training_manager.get_policy_state() if not env_attr.is_single_thread else None,
-                num_episodes=env_attr.num_eval_episodes,
+            cbm.on_episode_start(ep)
+
+            collect_time = training_time = 0.0
+            total_experiences: List[List[ExpElement]] = []
+            total_info_list: List[dict] = []
+            n_sample = 0
+            while n_sample < env_attr.min_n_sample:
+                tc0 = time.time()
+                result = env_sampler.sample(
+                    policy_state=training_manager.get_policy_state() if not env_attr.is_single_thread else None,
+                    num_steps=env_attr.num_steps,
+                )
+                experiences: List[List[ExpElement]] = result["experiences"]
+                info_list: List[dict] = result["info"]
+
+                n_sample += len(experiences[0])
+                total_experiences.extend(experiences)
+                total_info_list.extend(info_list)
+
+                collect_time += time.time() - tc0
+
+            env_sampler.post_collect(total_info_list, ep)
+
+            tu0 = time.time()
+            env_attr.logger.info(f"Roll-out completed for episode {ep}. Training started...")
+            cbm.on_training_start(ep)
+            training_manager.record_experiences(total_experiences)
+            training_manager.train_step()
+            cbm.on_training_end(ep)
+            training_time += time.time() - tu0
+
+            # performance details
+            env_attr.logger.info(
+                f"ep {ep} - roll-out time: {collect_time:.2f} seconds, training time: {training_time:.2f} seconds",
             )
-            env_sampler.post_evaluate(result["info"], ep)
+            if env_attr.eval_schedule and ep == env_attr.eval_schedule[eval_point_index]:
+                cbm.on_validation_start(ep)
 
-            cbm.call(SupportedCallbackFunc.ON_VALIDATION_END, env_sampler, training_manager, env_attr.logger, ep)
+                eval_point_index += 1
+                result = env_sampler.eval(
+                    policy_state=training_manager.get_policy_state() if not env_attr.is_single_thread else None,
+                    num_episodes=env_attr.num_eval_episodes,
+                )
+                env_sampler.post_evaluate(result["info"], ep)
 
-        cbm.call(SupportedCallbackFunc.ON_EPISODE_END, env_sampler, training_manager, env_attr.logger, ep)
+                cbm.on_validation_end(ep)
 
-    if isinstance(env_sampler, BatchEnvSampler):
-        env_sampler.exit()
-    training_manager.exit()
+            cbm.on_episode_end(ep)
+
+        if isinstance(env_sampler, BatchEnvSampler):
+            env_sampler.exit()
+        training_manager.exit()
 
 
 def evaluate_only_workflow(rl_component_bundle: RLComponentBundle, env_attr: WorkflowEnvAttributes) -> None:

--- a/tests/rl/gym_wrapper/common.py
+++ b/tests/rl/gym_wrapper/common.py
@@ -10,7 +10,7 @@ from tests.rl.gym_wrapper.simulator.business_engine import GymBusinessEngine
 env_conf = {
     "topology": "Walker2d-v4",  # HalfCheetah-v4, Hopper-v4, Walker2d-v4, Swimmer-v4, Ant-v4
     "start_tick": 0,
-    "durations": 1000,
+    "durations": 100000,  # Set a very large number
     "options": {
         "random_seed": None,
     },

--- a/tests/rl/gym_wrapper/common.py
+++ b/tests/rl/gym_wrapper/common.py
@@ -21,7 +21,8 @@ test_env = Env(business_engine_cls=GymBusinessEngine, **env_conf)
 num_agents = len(learn_env.agent_idx_list)
 
 gym_env = cast(GymBusinessEngine, learn_env.business_engine).gym_env
+gym_action_space = gym_env.action_space
 gym_state_dim = gym_env.observation_space.shape[0]
-gym_action_dim = gym_env.action_space.shape[0]
-action_lower_bound, action_upper_bound = gym_env.action_space.low, gym_env.action_space.high
-action_limit = gym_env.action_space.high[0]
+gym_action_dim = gym_action_space.shape[0]
+action_lower_bound, action_upper_bound = gym_action_space.low, gym_action_space.high
+action_limit = gym_action_space.high[0]

--- a/tests/rl/gym_wrapper/common.py
+++ b/tests/rl/gym_wrapper/common.py
@@ -4,8 +4,11 @@
 from typing import cast
 
 from maro.simulator import Env
+from maro.utils import set_seeds
 
 from tests.rl.gym_wrapper.simulator.business_engine import GymBusinessEngine
+
+set_seeds(123)
 
 env_conf = {
     "topology": "Walker2d-v4",  # HalfCheetah-v4, Hopper-v4, Walker2d-v4, Swimmer-v4, Ant-v4

--- a/tests/rl/gym_wrapper/simulator/business_engine.py
+++ b/tests/rl/gym_wrapper/simulator/business_engine.py
@@ -4,6 +4,7 @@
 from typing import List, Optional, cast
 
 import gym
+import numpy as np
 
 from maro.backends.frame import FrameBase, SnapshotList
 from maro.event_buffer import CascadeEvent, EventBuffer, MaroEvents
@@ -36,7 +37,6 @@ class GymBusinessEngine(AbsBusinessEngine):
 
         self._gym_scenario_name = topology
         self._gym_env = gym.make(self._gym_scenario_name)
-        self._seed = additional_options.get("random_seed", None)
 
         self.reset()
 
@@ -81,7 +81,7 @@ class GymBusinessEngine(AbsBusinessEngine):
         return self._info_record[tick]
 
     def reset(self, keep_seed: bool = False) -> None:
-        self._last_obs = self._gym_env.reset()[0]
+        self._last_obs = self._gym_env.reset(seed=np.random.randint(low=0, high=4096))[0]
         self._is_done = False
         self._truncated = False
         self._reward_record = {}

--- a/tests/rl/tasks/ppo/__init__.py
+++ b/tests/rl/tasks/ppo/__init__.py
@@ -54,6 +54,8 @@ rl_component_bundle = RLComponentBundle(
         test_env=test_env,
         policies=policies,
         agent2policy=agent2policy,
+        max_episode_length=1000,
+        
     ),
     agent2policy=agent2policy,
     policies=policies,

--- a/tests/rl/tasks/ppo/__init__.py
+++ b/tests/rl/tasks/ppo/__init__.py
@@ -55,7 +55,6 @@ rl_component_bundle = RLComponentBundle(
         policies=policies,
         agent2policy=agent2policy,
         max_episode_length=1000,
-        
     ),
     agent2policy=agent2policy,
     policies=policies,

--- a/tests/rl/tasks/sac/__init__.py
+++ b/tests/rl/tasks/sac/__init__.py
@@ -6,6 +6,7 @@ from typing import Tuple
 import numpy as np
 import torch
 import torch.nn.functional as F
+from gym import spaces
 from torch.distributions import Normal
 from torch.optim import Adam
 
@@ -14,12 +15,12 @@ from maro.rl.model.fc_block import FullyConnected
 from maro.rl.policy import ContinuousRLPolicy
 from maro.rl.rl_component.rl_component_bundle import RLComponentBundle
 from maro.rl.training.algorithms import SoftActorCriticParams, SoftActorCriticTrainer
-
 from tests.rl.gym_wrapper.common import (
     action_limit,
     action_lower_bound,
     action_upper_bound,
     gym_action_dim,
+    gym_action_space,
     gym_state_dim,
     learn_env,
     num_agents,
@@ -43,7 +44,7 @@ LOG_STD_MIN = -20
 
 
 class MyContinuousSACNet(ContinuousSACNet):
-    def __init__(self, state_dim: int, action_dim: int, action_limit: float) -> None:
+    def __init__(self, state_dim: int, action_dim: int, action_limit: float, action_space: spaces.Space) -> None:
         super(MyContinuousSACNet, self).__init__(state_dim=state_dim, action_dim=action_dim)
 
         self._net = FullyConnected(
@@ -57,6 +58,8 @@ class MyContinuousSACNet(ContinuousSACNet):
         self._log_std = torch.nn.Linear(actor_net_conf["hidden_dims"][-1], action_dim)
         self._action_limit = action_limit
         self._optim = Adam(self.parameters(), lr=actor_learning_rate)
+
+        self._action_space = action_space
 
     def _get_actions_with_logps_impl(self, states: torch.Tensor, exploring: bool) -> Tuple[torch.Tensor, torch.Tensor]:
         net_out = self._net(states.float())
@@ -73,6 +76,9 @@ class MyContinuousSACNet(ContinuousSACNet):
         pi_action = torch.tanh(pi_action) * self._action_limit
 
         return pi_action, logp_pi
+
+    def _get_random_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
+        return torch.stack([self._action_space.sample() for _ in range(states.shape[0])])
 
 
 class MyQCriticNet(QNet):
@@ -101,7 +107,7 @@ def get_sac_policy(
     return ContinuousRLPolicy(
         name=name,
         action_range=(action_lower_bound, action_upper_bound),
-        policy_net=MyContinuousSACNet(gym_state_dim, gym_action_dim, action_limit),
+        policy_net=MyContinuousSACNet(gym_state_dim, gym_action_dim, action_limit, action_space=gym_action_space),
     )
 
 
@@ -145,7 +151,6 @@ trainers = [get_sac_trainer(f"{algorithm}_{i}", gym_state_dim, gym_action_dim) f
 device_mapping = None
 if torch.cuda.is_available():
     device_mapping = {f"{algorithm}_{i}.policy": "cuda:0" for i in range(num_agents)}
-
 
 rl_component_bundle = RLComponentBundle(
     env_sampler=GymEnvSampler(

--- a/tests/rl/tasks/sac/__init__.py
+++ b/tests/rl/tasks/sac/__init__.py
@@ -133,9 +133,6 @@ def get_sac_trainer(name: str, state_dim: int, action_dim: int) -> SoftActorCrit
     )
 
 
-# TODO:
-#   1. random seed
-
 algorithm = "sac"
 agent2policy = {agent: f"{algorithm}_{agent}.policy" for agent in learn_env.agent_idx_list}
 policies = [

--- a/tests/rl/tasks/sac/__init__.py
+++ b/tests/rl/tasks/sac/__init__.py
@@ -16,6 +16,7 @@ from maro.rl.policy import ContinuousRLPolicy
 from maro.rl.rl_component.rl_component_bundle import RLComponentBundle
 from maro.rl.training.algorithms import SoftActorCriticParams, SoftActorCriticTrainer
 from maro.rl.utils import ndarray_to_tensor
+
 from tests.rl.gym_wrapper.common import (
     action_limit,
     action_lower_bound,
@@ -79,7 +80,9 @@ class MyContinuousSACNet(ContinuousSACNet):
         return pi_action, logp_pi
 
     def _get_random_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
-        return torch.stack([ndarray_to_tensor(self._action_space.sample(), device=self._device) for _ in range(states.shape[0])])
+        return torch.stack(
+            [ndarray_to_tensor(self._action_space.sample(), device=self._device) for _ in range(states.shape[0])],
+        )
 
 
 class MyQCriticNet(QNet):
@@ -132,8 +135,6 @@ def get_sac_trainer(name: str, state_dim: int, action_dim: int) -> SoftActorCrit
 
 # TODO:
 #   1. random seed
-#   2. exploration with random sampled action # start_steps=10000,  Number of steps for uniform-random action selection, before running real policy. Helps exploration.
-#   3. confirm the effect of (max_ep_len=1000)?
 
 algorithm = "sac"
 agent2policy = {agent: f"{algorithm}_{agent}.policy" for agent in learn_env.agent_idx_list}

--- a/tests/rl/tasks/sac/__init__.py
+++ b/tests/rl/tasks/sac/__init__.py
@@ -15,6 +15,7 @@ from maro.rl.model.fc_block import FullyConnected
 from maro.rl.policy import ContinuousRLPolicy
 from maro.rl.rl_component.rl_component_bundle import RLComponentBundle
 from maro.rl.training.algorithms import SoftActorCriticParams, SoftActorCriticTrainer
+from maro.rl.utils import ndarray_to_tensor
 from tests.rl.gym_wrapper.common import (
     action_limit,
     action_lower_bound,
@@ -78,7 +79,7 @@ class MyContinuousSACNet(ContinuousSACNet):
         return pi_action, logp_pi
 
     def _get_random_actions_impl(self, states: torch.Tensor) -> torch.Tensor:
-        return torch.stack([self._action_space.sample() for _ in range(states.shape[0])])
+        return torch.stack([ndarray_to_tensor(self._action_space.sample(), device=self._device) for _ in range(states.shape[0])])
 
 
 class MyQCriticNet(QNet):
@@ -108,6 +109,7 @@ def get_sac_policy(
         name=name,
         action_range=(action_lower_bound, action_upper_bound),
         policy_net=MyContinuousSACNet(gym_state_dim, gym_action_dim, action_limit, action_space=gym_action_space),
+        warmup=10000,
     )
 
 


### PR DESCRIPTION
# Description

<!--Please add a summary of the change here.
Please also add other related information/contexts/dependencies here.
-->

- Add episode truncation to `EnvSampler`. This is not identical to `duration` in `Env`.
  - `duration` is an internal attribute of `Env`. When `Env` has executed all the steps in the duration, it "terminates".
  - "Truncation" is a concept in `EnvSampler` and does not have to be perceived by `Env`. When a single episode reaches maximum episode length, it is "truncated".
- Refine callback-related logics. Add early stopping in training pipeline.

## Linked issue(s)/Pull request(s)

<!--Please add the related issue link(s) below.-->
- [issue_number](issue_link)

## Type of Change

- [ ] Non-breaking bug fix
- [ ] Breaking bug fix
- [ ] New feature
- [ ] Test
- [ ] Doc update
- [ ] Docker update

## Related Component

- [ ] Simulation toolkit
- [ ] RL toolkit
- [ ] Distributed toolkit

## Has Been Tested

- OS:
  - [ ] Windows
  - [ ] Mac OS
  - [ ] Linux
- Python version:
  - [ ] 3.7
  - [ ] 3.8
  - [ ] 3.9
- Key information snapshot(s):

## Needs Follow Up Actions

- [ ] New release package
- [ ] New docker image

## Checklist

- [ ] Add/update the related comments
- [ ] Add/update the related tests
- [ ] Add/update the related documentations
- [ ] Update the dependent downstream modules usage
